### PR TITLE
feat(m2): Stock Module — 매매 CRUD, FIFO, 포트폴리오, 프론트엔드

### DIFF
--- a/apps/api/src/stock/controllers/account.controller.spec.ts
+++ b/apps/api/src/stock/controllers/account.controller.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AccountController } from './account.controller';
+import { StockService } from '../services/stock.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+const mockStockService = {
+  getAccounts: jest.fn(),
+  createAccount: jest.fn(),
+};
+
+const mockReq = { user: { id: 'user-1' } };
+
+describe('AccountController', () => {
+  let controller: AccountController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AccountController],
+      providers: [
+        { provide: StockService, useValue: mockStockService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<AccountController>(AccountController);
+    jest.clearAllMocks();
+  });
+
+  it('컨트롤러가 정의된다', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('JwtAuthGuard 적용', () => {
+    it('컨트롤러 클래스에 JwtAuthGuard가 적용되어 있다', () => {
+      const guards = Reflect.getMetadata('__guards__', AccountController);
+      expect(guards).toBeDefined();
+      expect(guards.some((g: Function) => g === JwtAuthGuard)).toBe(true);
+    });
+  });
+
+  describe('findAll (GET /stock-accounts)', () => {
+    it('StockService.getAccounts를 userId로 호출하고 결과를 반환한다', async () => {
+      const mockAccounts = [
+        { id: 'acc-1', userId: 'user-1', type: 'GENERAL', broker: '키움', alias: null, isActive: true },
+        { id: 'acc-2', userId: 'user-1', type: 'ISA', broker: '미래에셋', alias: '연금ISA', isActive: true },
+      ];
+      mockStockService.getAccounts.mockResolvedValue(mockAccounts);
+
+      const result = await controller.findAll(mockReq);
+
+      expect(mockStockService.getAccounts).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(mockAccounts);
+    });
+  });
+
+  describe('create (POST /stock-accounts)', () => {
+    it('StockService.createAccount를 userId와 body로 호출하고 생성된 계좌를 반환한다', async () => {
+      const mockAccount = {
+        id: 'acc-new',
+        userId: 'user-1',
+        type: 'ISA',
+        broker: '미래에셋',
+        alias: '연금ISA',
+        isActive: true,
+        createdAt: new Date(),
+      };
+      mockStockService.createAccount.mockResolvedValue(mockAccount);
+
+      const body = { type: 'ISA' as const, broker: '미래에셋', alias: '연금ISA' };
+      const result = await controller.create(mockReq, body);
+
+      expect(mockStockService.createAccount).toHaveBeenCalledWith('user-1', body);
+      expect(result).toEqual(mockAccount);
+    });
+
+    it('alias 없이도 계좌를 생성할 수 있다', async () => {
+      const mockAccount = {
+        id: 'acc-new',
+        userId: 'user-1',
+        type: 'GENERAL',
+        broker: '키움',
+        alias: undefined,
+        isActive: true,
+        createdAt: new Date(),
+      };
+      mockStockService.createAccount.mockResolvedValue(mockAccount);
+
+      const body = { type: 'GENERAL' as const, broker: '키움' };
+      const result = await controller.create(mockReq, body);
+
+      expect(mockStockService.createAccount).toHaveBeenCalledWith('user-1', body);
+      expect(result).toEqual(mockAccount);
+    });
+  });
+});

--- a/apps/api/src/stock/controllers/portfolio.controller.spec.ts
+++ b/apps/api/src/stock/controllers/portfolio.controller.spec.ts
@@ -1,0 +1,109 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PortfolioController } from './portfolio.controller';
+import { PortfolioService } from '../services/portfolio.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+const mockPortfolioService = {
+  getSummary: jest.fn(),
+  getHoldings: jest.fn(),
+  getPerformance: jest.fn(),
+};
+
+const mockReq = { user: { id: 'user-1' } };
+
+describe('PortfolioController', () => {
+  let controller: PortfolioController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PortfolioController],
+      providers: [{ provide: PortfolioService, useValue: mockPortfolioService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<PortfolioController>(PortfolioController);
+    jest.clearAllMocks();
+  });
+
+  it('컨트롤러가 정의된다', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('JwtAuthGuard 적용', () => {
+    it('컨트롤러 클래스에 JwtAuthGuard가 적용되어 있다', () => {
+      const guards = Reflect.getMetadata('__guards__', PortfolioController);
+      expect(guards).toBeDefined();
+      expect(guards.some((g: Function) => g === JwtAuthGuard)).toBe(true);
+    });
+  });
+
+  describe('getSummary (GET /portfolio/summary)', () => {
+    it('PortfolioService.getSummary를 userId와 accountId로 호출한다', async () => {
+      const mockSummary = {
+        totalEvaluation: 700000,
+        totalInvested: 600000,
+        totalUnrealizedGain: 100000,
+        totalUnrealizedGainRate: 16.67,
+        totalRealizedGain: 50000,
+      };
+      mockPortfolioService.getSummary.mockResolvedValue(mockSummary);
+
+      const result = await controller.getSummary(mockReq, 'acc-1');
+
+      expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', 'acc-1');
+      expect(result).toEqual(mockSummary);
+    });
+
+    it('accountId 없이 호출하면 undefined를 전달한다', async () => {
+      mockPortfolioService.getSummary.mockResolvedValue({});
+
+      await controller.getSummary(mockReq, undefined);
+
+      expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', undefined);
+    });
+  });
+
+  describe('getHoldings (GET /portfolio/holdings)', () => {
+    it('PortfolioService.getHoldings를 userId와 accountId로 호출한다', async () => {
+      const mockHoldings = [
+        {
+          stockId: 's1',
+          stockName: '삼성전자',
+          stockCode: 'KRX001',
+          quantity: 10,
+          avgBuyPrice: 60000,
+          currentPrice: 70000,
+          evaluation: 700000,
+          invested: 600000,
+          unrealizedGain: 100000,
+          unrealizedGainRate: 16.67,
+          weight: 100,
+        },
+      ];
+      mockPortfolioService.getHoldings.mockResolvedValue(mockHoldings);
+
+      const result = await controller.getHoldings(mockReq, 'acc-1');
+
+      expect(mockPortfolioService.getHoldings).toHaveBeenCalledWith('user-1', 'acc-1');
+      expect(result).toEqual(mockHoldings);
+    });
+  });
+
+  describe('getPerformance (GET /portfolio/performance)', () => {
+    it('PortfolioService.getPerformance를 userId, year, accountId로 호출한다', async () => {
+      const mockPerformance = Array.from({ length: 12 }, (_, i) => ({
+        month: `2026-${String(i + 1).padStart(2, '0')}`,
+        realizedGain: 0,
+        tradeCount: 0,
+      }));
+      mockPortfolioService.getPerformance.mockResolvedValue(mockPerformance);
+
+      const result = await controller.getPerformance(mockReq, 2026, 'acc-1');
+
+      expect(mockPortfolioService.getPerformance).toHaveBeenCalledWith('user-1', 2026, 'acc-1');
+      expect(result).toHaveLength(12);
+    });
+  });
+});

--- a/apps/api/src/stock/controllers/stock.controller.spec.ts
+++ b/apps/api/src/stock/controllers/stock.controller.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StockController } from './stock.controller';
+import { StockService } from '../services/stock.service';
+import { StockPriceService } from '../services/stock-price.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+const mockStockService = {
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+};
+
+const mockStockPriceService = {
+  getPrice: jest.fn(),
+};
+
+const mockStock = {
+  id: 's1',
+  code: 'KRX001',
+  name: '삼성전자',
+  market: 'KRX',
+  isActive: true,
+};
+
+describe('StockController', () => {
+  let controller: StockController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StockController],
+      providers: [
+        { provide: StockService, useValue: mockStockService },
+        { provide: StockPriceService, useValue: mockStockPriceService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<StockController>(StockController);
+    jest.clearAllMocks();
+  });
+
+  it('컨트롤러가 정의된다', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('JwtAuthGuard 적용', () => {
+    it('컨트롤러 클래스에 JwtAuthGuard가 적용되어 있다', () => {
+      const guards = Reflect.getMetadata('__guards__', StockController);
+      expect(guards).toBeDefined();
+      expect(guards.some((g: Function) => g === JwtAuthGuard)).toBe(true);
+    });
+  });
+
+  describe('findAll (GET /stocks)', () => {
+    it('StockService.findAll을 검색어 없이 호출한다', async () => {
+      mockStockService.findAll.mockResolvedValue([mockStock]);
+
+      const result = await controller.findAll(undefined);
+
+      expect(mockStockService.findAll).toHaveBeenCalledWith(undefined);
+      expect(result).toEqual([mockStock]);
+    });
+
+    it('검색어를 전달하면 StockService.findAll에 검색어를 넘긴다', async () => {
+      mockStockService.findAll.mockResolvedValue([mockStock]);
+
+      const result = await controller.findAll('삼성');
+
+      expect(mockStockService.findAll).toHaveBeenCalledWith('삼성');
+      expect(result).toEqual([mockStock]);
+    });
+  });
+
+  describe('findOne (GET /stocks/:id)', () => {
+    it('StockService.findOne을 id로 호출한다', async () => {
+      const stockWithPrices = { ...mockStock, stockPrices: [] };
+      mockStockService.findOne.mockResolvedValue(stockWithPrices);
+
+      const result = await controller.findOne('s1');
+
+      expect(mockStockService.findOne).toHaveBeenCalledWith('s1');
+      expect(result).toEqual(stockWithPrices);
+    });
+  });
+
+  describe('getPrice (GET /stocks/:id/price)', () => {
+    it('StockPriceService.getPrice를 stockId로 호출한다', async () => {
+      const mockPrice = {
+        price: 70000,
+        change: 500,
+        changeRate: 0.72,
+        fetchedAt: new Date(),
+        isCached: true,
+      };
+      mockStockPriceService.getPrice.mockResolvedValue(mockPrice);
+
+      const result = await controller.getPrice('s1');
+
+      expect(mockStockPriceService.getPrice).toHaveBeenCalledWith('s1');
+      expect(result).toEqual(mockPrice);
+    });
+  });
+
+  describe('create (POST /stocks)', () => {
+    it('StockService.create를 body 데이터로 호출한다', async () => {
+      mockStockService.create.mockResolvedValue(mockStock);
+
+      const body = { code: 'KRX001', name: '삼성전자', market: 'KRX' };
+      const result = await controller.create(body);
+
+      expect(mockStockService.create).toHaveBeenCalledWith(body);
+      expect(result).toEqual(mockStock);
+    });
+  });
+});

--- a/apps/api/src/stock/controllers/trade.controller.spec.ts
+++ b/apps/api/src/stock/controllers/trade.controller.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TradeController } from './trade.controller';
+import { TradeService } from '../services/trade.service';
+import { FifoService } from '../services/fifo.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CreateTradeDto } from '../dto/create-trade.dto';
+import { UpdateTradeDto } from '../dto/update-trade.dto';
+import { QueryTradeDto } from '../dto/query-trade.dto';
+
+const mockTradeService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+};
+
+const mockFifoService = {
+  calculateRealizedGain: jest.fn(),
+  getRealizedGainsByTrade: jest.fn(),
+  getTotalRealizedGain: jest.fn(),
+};
+
+const mockReq = { user: { id: 'user-001' } };
+const TRADE_ID = 'trade-001';
+
+describe('TradeController', () => {
+  let controller: TradeController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TradeController],
+      providers: [
+        { provide: TradeService, useValue: mockTradeService },
+        { provide: FifoService, useValue: mockFifoService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<TradeController>(TradeController);
+  });
+
+  it('컨트롤러가 정의된다', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────
+  describe('JwtAuthGuard 적용', () => {
+    it('컨트롤러 클래스에 JwtAuthGuard가 적용되어 있다', () => {
+      const guards = Reflect.getMetadata('__guards__', TradeController);
+      expect(guards).toBeDefined();
+      expect(guards.some((g: Function) => g === JwtAuthGuard)).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('create (POST /trades)', () => {
+    it('TradeService.create를 userId와 dto로 호출하고 결과를 반환한다', async () => {
+      const dto: CreateTradeDto = {
+        stockId: 'stock-001',
+        accountId: 'acc-001',
+        type: 'BUY',
+        tradeDate: '2026-01-15',
+        price: 50000,
+        quantity: 10,
+      };
+      const expected = { id: TRADE_ID, ...dto };
+      mockTradeService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(mockReq, dto);
+
+      expect(mockTradeService.create).toHaveBeenCalledWith('user-001', dto);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('findAll (GET /trades)', () => {
+    it('TradeService.findAll을 userId와 query로 호출하고 결과를 반환한다', async () => {
+      const query = new QueryTradeDto();
+      const expected = { data: [], total: 0, page: 1, limit: 20, totalPages: 0 };
+      mockTradeService.findAll.mockResolvedValue(expected);
+
+      const result = await controller.findAll(mockReq, query);
+
+      expect(mockTradeService.findAll).toHaveBeenCalledWith('user-001', query);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('findOne (GET /trades/:id)', () => {
+    it('TradeService.findOne을 userId와 id로 호출하고 결과를 반환한다', async () => {
+      const expected = { id: TRADE_ID, type: 'BUY' };
+      mockTradeService.findOne.mockResolvedValue(expected);
+
+      const result = await controller.findOne(mockReq, TRADE_ID);
+
+      expect(mockTradeService.findOne).toHaveBeenCalledWith('user-001', TRADE_ID);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('getRealizedGains (GET /trades/:id/realized-gains)', () => {
+    it('FifoService.getRealizedGainsByTrade를 tradeId로 호출하고 결과를 반환한다', async () => {
+      const gains = [{ id: 'rg-001', gain: 100000 }];
+      mockFifoService.getRealizedGainsByTrade.mockResolvedValue(gains);
+
+      const result = await controller.getRealizedGains(TRADE_ID);
+
+      expect(mockFifoService.getRealizedGainsByTrade).toHaveBeenCalledWith(
+        TRADE_ID,
+      );
+      expect(result).toEqual(gains);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('update (PUT /trades/:id)', () => {
+    it('TradeService.update를 userId, id, dto로 호출하고 결과를 반환한다', async () => {
+      const dto: UpdateTradeDto = { price: 55000 };
+      const expected = { id: TRADE_ID, price: 55000 };
+      mockTradeService.update.mockResolvedValue(expected);
+
+      const result = await controller.update(mockReq, TRADE_ID, dto);
+
+      expect(mockTradeService.update).toHaveBeenCalledWith(
+        'user-001',
+        TRADE_ID,
+        dto,
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('remove (DELETE /trades/:id)', () => {
+    it('TradeService.remove를 userId와 id로 호출하고 결과를 반환한다', async () => {
+      const expected = { deleted: true };
+      mockTradeService.remove.mockResolvedValue(expected);
+
+      const result = await controller.remove(mockReq, TRADE_ID);
+
+      expect(mockTradeService.remove).toHaveBeenCalledWith('user-001', TRADE_ID);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/api/src/stock/services/fifo.service.spec.ts
+++ b/apps/api/src/stock/services/fifo.service.spec.ts
@@ -1,0 +1,449 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { FifoService } from './fifo.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const USER_ID = 'user-001';
+const STOCK_ID = 'stock-001';
+const ACCOUNT_ID = 'account-001';
+
+// Helper to build a minimal trade object
+function makeTrade(
+  id: string,
+  type: 'BUY' | 'SELL',
+  price: number,
+  quantity: number,
+  tradeDateStr: string,
+) {
+  return {
+    id,
+    userId: USER_ID,
+    stockId: STOCK_ID,
+    accountId: ACCOUNT_ID,
+    type,
+    price,
+    quantity,
+    tradeDate: new Date(tradeDateStr),
+    reason: [],
+    memo: null,
+  };
+}
+
+const mockPrisma = {
+  trade: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+  },
+  realizedGain: {
+    findMany: jest.fn(),
+    createMany: jest.fn(),
+    aggregate: jest.fn(),
+  },
+};
+
+describe('FifoService', () => {
+  let service: FifoService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FifoService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<FifoService>(FifoService);
+  });
+
+  it('서비스가 정의된다', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────
+  describe('calculateRealizedGain - FIFO 실현손익 계산', () => {
+    describe('입력 유효성 검증', () => {
+      it('존재하지 않는 거래 ID면 BadRequestException을 던진다', async () => {
+        mockPrisma.trade.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.calculateRealizedGain('nonexistent'),
+        ).rejects.toThrow(BadRequestException);
+        await expect(
+          service.calculateRealizedGain('nonexistent'),
+        ).rejects.toThrow('유효한 매도 거래가 아닙니다.');
+      });
+
+      it('SELL 타입이 아닌 거래면 BadRequestException을 던진다', async () => {
+        const buyTrade = makeTrade('buy-001', 'BUY', 50000, 10, '2026-01-15');
+        mockPrisma.trade.findUnique.mockResolvedValue(buyTrade);
+
+        await expect(
+          service.calculateRealizedGain('buy-001'),
+        ).rejects.toThrow(BadRequestException);
+        await expect(
+          service.calculateRealizedGain('buy-001'),
+        ).rejects.toThrow('유효한 매도 거래가 아닙니다.');
+      });
+    });
+
+    describe('단순 FIFO 매칭 — 매수 1건, 전량 매도', () => {
+      it('전량 매도 시 1개의 실현이익 레코드를 생성한다', async () => {
+        const sellTrade = makeTrade('sell-001', 'SELL', 60000, 10, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 50000, 10, '2026-01-15');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await service.calculateRealizedGain('sell-001');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            {
+              buyTradeId: 'buy-001',
+              sellTradeId: 'sell-001',
+              quantity: 10,
+              buyPrice: 50000,
+              sellPrice: 60000,
+              gain: (60000 - 50000) * 10, // 100_000
+            },
+          ],
+        });
+      });
+
+      it('이익 금액을 올바르게 계산한다 (차익)', async () => {
+        const sellTrade = makeTrade('sell-001', 'SELL', 70000, 5, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 40000, 5, '2026-01-15');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await service.calculateRealizedGain('sell-001');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            expect.objectContaining({
+              gain: (70000 - 40000) * 5, // 150_000
+            }),
+          ],
+        });
+      });
+
+      it('손실 시나리오에서 음수 gain을 올바르게 계산한다', async () => {
+        const sellTrade = makeTrade('sell-001', 'SELL', 30000, 5, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 50000, 5, '2026-01-15');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await service.calculateRealizedGain('sell-001');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            expect.objectContaining({
+              gain: (30000 - 50000) * 5, // -100_000
+            }),
+          ],
+        });
+      });
+    });
+
+    describe('복수 매수, 부분 매도 — FIFO 순서 검증', () => {
+      it('복수의 매수 건에서 FIFO 순서로 매칭하여 복수 레코드를 생성한다', async () => {
+        // buy-001: 10주 @ 40000 (먼저)
+        // buy-002: 10주 @ 50000 (나중)
+        // sell: 15주 → buy-001에서 10, buy-002에서 5
+        const sellTrade = makeTrade('sell-001', 'SELL', 60000, 15, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 40000, 10, '2026-01-10');
+        const buyTrade2 = makeTrade('buy-002', 'BUY', 50000, 10, '2026-02-01');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1, buyTrade2]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 2 });
+
+        await service.calculateRealizedGain('sell-001');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            {
+              buyTradeId: 'buy-001',
+              sellTradeId: 'sell-001',
+              quantity: 10,
+              buyPrice: 40000,
+              sellPrice: 60000,
+              gain: (60000 - 40000) * 10,
+            },
+            {
+              buyTradeId: 'buy-002',
+              sellTradeId: 'sell-001',
+              quantity: 5,
+              buyPrice: 50000,
+              sellPrice: 60000,
+              gain: (60000 - 50000) * 5,
+            },
+          ],
+        });
+      });
+    });
+
+    describe('이미 사용된 매수 수량 처리', () => {
+      it('기존 RealizedGain에서 이미 소진된 수량을 제외하고 남은 수량만 사용한다', async () => {
+        // buy-001: 10주 @ 40000
+        // 기존 정산: buy-001에서 6주 이미 사용
+        // sell: 4주 → buy-001에서 남은 4주만 매칭
+        const sellTrade = makeTrade('sell-002', 'SELL', 60000, 4, '2026-04-01');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 40000, 10, '2026-01-10');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        // 이미 6주 사용됨
+        mockPrisma.realizedGain.findMany.mockResolvedValue([
+          { buyTradeId: 'buy-001', quantity: 6 },
+        ]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await service.calculateRealizedGain('sell-002');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            {
+              buyTradeId: 'buy-001',
+              sellTradeId: 'sell-002',
+              quantity: 4, // 10 - 6 = 4 남음
+              buyPrice: 40000,
+              sellPrice: 60000,
+              gain: (60000 - 40000) * 4,
+            },
+          ],
+        });
+      });
+
+      it('모든 매수 수량이 이미 사용됐고 잔여가 없을 때 BadRequestException을 던진다', async () => {
+        const sellTrade = makeTrade('sell-003', 'SELL', 60000, 5, '2026-04-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 40000, 10, '2026-01-10');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        // buy-001 전량 소진
+        mockPrisma.realizedGain.findMany.mockResolvedValue([
+          { buyTradeId: 'buy-001', quantity: 10 },
+        ]);
+
+        await expect(
+          service.calculateRealizedGain('sell-003'),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('여러 기존 정산이 있을 때 누적 사용 수량을 올바르게 집계한다', async () => {
+        // buy-001: 10주
+        // 기존 정산: 3주 + 4주 = 7주 사용
+        // sell: 3주 → 나머지 3주 매칭
+        const sellTrade = makeTrade('sell-004', 'SELL', 65000, 3, '2026-05-01');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 45000, 10, '2026-01-10');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([
+          { buyTradeId: 'buy-001', quantity: 3 },
+          { buyTradeId: 'buy-001', quantity: 4 },
+        ]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await service.calculateRealizedGain('sell-004');
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            expect.objectContaining({
+              buyTradeId: 'buy-001',
+              quantity: 3, // 10 - 7 = 3
+            }),
+          ],
+        });
+      });
+    });
+
+    describe('매수 수량 부족', () => {
+      it('매수 내역이 전혀 없을 때 BadRequestException을 던진다', async () => {
+        const sellTrade = makeTrade('sell-001', 'SELL', 60000, 5, '2026-03-15');
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+        await expect(
+          service.calculateRealizedGain('sell-001'),
+        ).rejects.toThrow(BadRequestException);
+        await expect(
+          service.calculateRealizedGain('sell-001'),
+        ).rejects.toThrow('FIFO 매칭 실패');
+      });
+
+      it('매수 수량이 매도 수량보다 부족할 때 BadRequestException을 던진다', async () => {
+        // buy: 3주, sell: 5주 → 2주 부족
+        const sellTrade = makeTrade('sell-001', 'SELL', 60000, 5, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 40000, 3, '2026-01-10');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+        await expect(
+          service.calculateRealizedGain('sell-001'),
+        ).rejects.toThrow(BadRequestException);
+        expect(mockPrisma.realizedGain.createMany).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('경계값 테스트', () => {
+      it('정확히 수량이 일치할 때 정상적으로 처리한다', async () => {
+        const sellTrade = makeTrade('sell-001', 'SELL', 55000, 7, '2026-03-15');
+        const buyTrade1 = makeTrade('buy-001', 'BUY', 45000, 7, '2026-01-10');
+
+        mockPrisma.trade.findUnique.mockResolvedValue(sellTrade);
+        mockPrisma.trade.findMany.mockResolvedValue([buyTrade1]);
+        mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+        mockPrisma.realizedGain.createMany.mockResolvedValue({ count: 1 });
+
+        await expect(
+          service.calculateRealizedGain('sell-001'),
+        ).resolves.not.toThrow();
+
+        expect(mockPrisma.realizedGain.createMany).toHaveBeenCalledWith({
+          data: [
+            expect.objectContaining({ quantity: 7, gain: (55000 - 45000) * 7 }),
+          ],
+        });
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('getRealizedGainsByTrade - 매도 거래별 실현이익 조회', () => {
+    it('sellTradeId에 해당하는 실현이익 목록을 buyTrade 포함하여 반환한다', async () => {
+      const gains = [
+        {
+          id: 'rg-001',
+          sellTradeId: 'sell-001',
+          buyTradeId: 'buy-001',
+          quantity: 5,
+          buyPrice: 40000,
+          sellPrice: 60000,
+          gain: 100000,
+          buyTrade: {
+            id: 'buy-001',
+            stock: { id: STOCK_ID, ticker: 'AAPL' },
+          },
+        },
+      ];
+      mockPrisma.realizedGain.findMany.mockResolvedValue(gains);
+
+      const result = await service.getRealizedGainsByTrade('sell-001');
+
+      expect(mockPrisma.realizedGain.findMany).toHaveBeenCalledWith({
+        where: { sellTradeId: 'sell-001' },
+        include: {
+          buyTrade: { include: { stock: true } },
+        },
+        orderBy: { buyTrade: { tradeDate: 'asc' } },
+      });
+      expect(result).toEqual(gains);
+    });
+
+    it('해당하는 이익 레코드가 없으면 빈 배열을 반환한다', async () => {
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getRealizedGainsByTrade('sell-999');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('getTotalRealizedGain - 누적 실현이익 집계', () => {
+    it('userId로 전체 실현이익 합산을 반환한다', async () => {
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({
+        _sum: { gain: 500000 },
+      });
+
+      const result = await service.getTotalRealizedGain(USER_ID);
+
+      expect(mockPrisma.realizedGain.aggregate).toHaveBeenCalledWith({
+        where: { sellTrade: { userId: USER_ID } },
+        _sum: { gain: true },
+      });
+      expect(result).toBe(500000);
+    });
+
+    it('stockId 필터를 포함하여 집계한다', async () => {
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({
+        _sum: { gain: 200000 },
+      });
+
+      const result = await service.getTotalRealizedGain(USER_ID, STOCK_ID);
+
+      expect(mockPrisma.realizedGain.aggregate).toHaveBeenCalledWith({
+        where: { sellTrade: { userId: USER_ID, stockId: STOCK_ID } },
+        _sum: { gain: true },
+      });
+      expect(result).toBe(200000);
+    });
+
+    it('accountId 필터를 포함하여 집계한다', async () => {
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({
+        _sum: { gain: 150000 },
+      });
+
+      const result = await service.getTotalRealizedGain(
+        USER_ID,
+        undefined,
+        ACCOUNT_ID,
+      );
+
+      expect(mockPrisma.realizedGain.aggregate).toHaveBeenCalledWith({
+        where: { sellTrade: { userId: USER_ID, accountId: ACCOUNT_ID } },
+        _sum: { gain: true },
+      });
+      expect(result).toBe(150000);
+    });
+
+    it('stockId와 accountId 모두 지정하여 집계한다', async () => {
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({
+        _sum: { gain: 80000 },
+      });
+
+      const result = await service.getTotalRealizedGain(
+        USER_ID,
+        STOCK_ID,
+        ACCOUNT_ID,
+      );
+
+      expect(mockPrisma.realizedGain.aggregate).toHaveBeenCalledWith({
+        where: {
+          sellTrade: {
+            userId: USER_ID,
+            stockId: STOCK_ID,
+            accountId: ACCOUNT_ID,
+          },
+        },
+        _sum: { gain: true },
+      });
+      expect(result).toBe(80000);
+    });
+
+    it('실현이익이 없을 때 0을 반환한다', async () => {
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({
+        _sum: { gain: null },
+      });
+
+      const result = await service.getTotalRealizedGain(USER_ID);
+
+      expect(result).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/stock/services/portfolio.service.spec.ts
+++ b/apps/api/src/stock/services/portfolio.service.spec.ts
@@ -1,0 +1,241 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PortfolioService } from './portfolio.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const mockPrisma = {
+  trade: { findMany: jest.fn() },
+  realizedGain: {
+    findMany: jest.fn(),
+    aggregate: jest.fn(),
+  },
+};
+
+const makeStock = (id: string, code: string, name: string, price: number) => ({
+  id,
+  code,
+  name,
+  isActive: true,
+  market: 'KRX',
+  stockPrices: price ? [{ stockId: id, price, change: 0, changeRate: 0, fetchedAt: new Date() }] : [],
+});
+
+const makeTrade = (
+  id: string,
+  userId: string,
+  stockId: string,
+  type: 'BUY' | 'SELL',
+  quantity: number,
+  price: number,
+  stock: ReturnType<typeof makeStock>,
+  tradeDate = new Date('2026-01-10'),
+  accountId?: string,
+) => ({
+  id,
+  userId,
+  stockId,
+  type,
+  quantity,
+  price,
+  tradeDate,
+  accountId: accountId ?? 'acc-1',
+  stock,
+});
+
+describe('PortfolioService', () => {
+  let service: PortfolioService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<PortfolioService>(PortfolioService);
+    jest.clearAllMocks();
+  });
+
+  describe('getHoldings', () => {
+    it('거래 내역이 없으면 빈 배열을 반환한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getHoldings('user-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('매수만 있는 경우 올바른 avgBuyPrice와 evaluation을 계산한다', async () => {
+      const stock = makeStock('s1', 'KRX001', '삼성전자', 70000);
+      const trades = [
+        makeTrade('t1', 'user-1', 's1', 'BUY', 10, 60000, stock),
+      ];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getHoldings('user-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].stockId).toBe('s1');
+      expect(result[0].quantity).toBe(10);
+      expect(result[0].avgBuyPrice).toBe(60000);
+      expect(result[0].evaluation).toBe(700000); // 70000 * 10
+      expect(result[0].weight).toBe(100);
+    });
+
+    it('매수 후 일부 매도 시 avgBuyPrice를 매도 원가 제외하여 계산한다', async () => {
+      const stock = makeStock('s1', 'KRX001', '삼성전자', 70000);
+      const trades = [
+        makeTrade('t1', 'user-1', 's1', 'BUY', 10, 60000, stock, new Date('2026-01-01')),
+        makeTrade('t2', 'user-1', 's1', 'SELL', 3, 70000, stock, new Date('2026-01-05')),
+      ];
+      // realizedGain: 매도 3주, 매수가 60000
+      const gains = [
+        { id: 'g1', buyTradeId: 't1', sellTradeId: 't2', quantity: 3, buyPrice: 60000, gain: 30000, sellTrade: trades[1] },
+      ];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.realizedGain.findMany.mockResolvedValue(gains);
+
+      const result = await service.getHoldings('user-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].quantity).toBe(7); // 10 - 3
+      // totalBuyCost = 600000, soldCost = 180000, remaining = 420000, avgBuyPrice = 420000/7 = 60000
+      expect(result[0].avgBuyPrice).toBe(60000);
+    });
+
+    it('여러 종목이 있을 때 evaluation 내림차순으로 정렬되고 weight 합이 100%가 된다', async () => {
+      const stockA = makeStock('sA', 'A001', '종목A', 100000);
+      const stockB = makeStock('sB', 'B001', '종목B', 50000);
+      const trades = [
+        makeTrade('t1', 'user-1', 'sA', 'BUY', 2, 80000, stockA), // eval: 200000
+        makeTrade('t2', 'user-1', 'sB', 'BUY', 5, 40000, stockB), // eval: 250000
+      ];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getHoldings('user-1');
+
+      expect(result).toHaveLength(2);
+      // sB has higher eval (250000) → comes first
+      expect(result[0].stockId).toBe('sB');
+      expect(result[1].stockId).toBe('sA');
+
+      const totalWeight = result.reduce((s, h) => s + h.weight, 0);
+      expect(totalWeight).toBeCloseTo(100, 1);
+    });
+
+    it('전량 매도한 종목은 결과에서 제외된다', async () => {
+      const stock = makeStock('s1', 'KRX001', '삼성전자', 70000);
+      const trades = [
+        makeTrade('t1', 'user-1', 's1', 'BUY', 5, 60000, stock, new Date('2026-01-01')),
+        makeTrade('t2', 'user-1', 's1', 'SELL', 5, 70000, stock, new Date('2026-01-05')),
+      ];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getHoldings('user-1');
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('accountId 필터를 전달하면 trade 조회 where 절에 포함된다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      await service.getHoldings('user-1', 'acc-99');
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: 'user-1', accountId: 'acc-99' }),
+        }),
+      );
+    });
+  });
+
+  describe('getSummary', () => {
+    it('보유 종목이 없을 때 모든 합계가 0이다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({ _sum: { gain: null } });
+
+      const result = await service.getSummary('user-1');
+
+      expect(result.totalEvaluation).toBe(0);
+      expect(result.totalInvested).toBe(0);
+      expect(result.totalUnrealizedGain).toBe(0);
+      expect(result.totalUnrealizedGainRate).toBe(0);
+      expect(result.totalRealizedGain).toBe(0);
+    });
+
+    it('보유 종목과 실현손익이 있을 때 올바른 합계를 계산한다', async () => {
+      const stock = makeStock('s1', 'KRX001', '삼성전자', 70000);
+      const trades = [
+        makeTrade('t1', 'user-1', 's1', 'BUY', 10, 60000, stock),
+      ];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+      mockPrisma.realizedGain.aggregate.mockResolvedValue({ _sum: { gain: 50000 } });
+
+      const result = await service.getSummary('user-1');
+
+      expect(result.totalEvaluation).toBe(700000); // 70000 * 10
+      expect(result.totalInvested).toBe(600000);   // 60000 * 10
+      expect(result.totalUnrealizedGain).toBe(100000);
+      expect(result.totalUnrealizedGainRate).toBeCloseTo(16.67, 1);
+      expect(result.totalRealizedGain).toBe(50000);
+    });
+  });
+
+  describe('getPerformance', () => {
+    it('거래 내역이 없어도 12개월 항목을 반환한다', async () => {
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      const result = await service.getPerformance('user-1', 2026);
+
+      expect(result).toHaveLength(12);
+      result.forEach((item) => {
+        expect(item.realizedGain).toBe(0);
+        expect(item.tradeCount).toBe(0);
+      });
+    });
+
+    it('실현이익을 월별로 올바르게 집계한다', async () => {
+      const sellTrade1 = { id: 'st1', tradeDate: new Date('2026-03-15'), userId: 'user-1', accountId: 'acc-1' };
+      const sellTrade2 = { id: 'st2', tradeDate: new Date('2026-03-20'), userId: 'user-1', accountId: 'acc-1' };
+      const gains = [
+        { id: 'g1', sellTradeId: 'st1', buyTradeId: 'bt1', gain: 30000, quantity: 5, buyPrice: 60000, sellTrade: sellTrade1 },
+        { id: 'g2', sellTradeId: 'st1', buyTradeId: 'bt2', gain: 10000, quantity: 2, buyPrice: 60000, sellTrade: sellTrade1 },
+        { id: 'g3', sellTradeId: 'st2', buyTradeId: 'bt3', gain: 20000, quantity: 3, buyPrice: 60000, sellTrade: sellTrade2 },
+      ];
+      mockPrisma.realizedGain.findMany.mockResolvedValue(gains);
+
+      const result = await service.getPerformance('user-1', 2026);
+
+      const march = result.find((r) => r.month === '2026-03');
+      expect(march).toBeDefined();
+      expect(march!.realizedGain).toBe(60000); // 30000 + 10000 + 20000
+      // st1 and st2 are 2 distinct trade IDs
+      expect(march!.tradeCount).toBe(2);
+
+      // other months should be 0
+      const jan = result.find((r) => r.month === '2026-01');
+      expect(jan!.realizedGain).toBe(0);
+    });
+
+    it('accountId 필터를 적용하면 realizedGain 조회 where 절에 포함된다', async () => {
+      mockPrisma.realizedGain.findMany.mockResolvedValue([]);
+
+      await service.getPerformance('user-1', 2026, 'acc-99');
+
+      expect(mockPrisma.realizedGain.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            sellTrade: expect.objectContaining({ accountId: 'acc-99' }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/stock/services/stock-price.service.spec.ts
+++ b/apps/api/src/stock/services/stock-price.service.spec.ts
@@ -1,0 +1,163 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StockPriceService } from './stock-price.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const mockPrisma = {
+  stockPrice: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+const freshDate = () => new Date(Date.now() - 60 * 1000); // 1분 전 (캐시 유효)
+const staleDate = () => new Date(Date.now() - 10 * 60 * 1000); // 10분 전 (캐시 만료)
+
+describe('StockPriceService', () => {
+  let service: StockPriceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StockPriceService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<StockPriceService>(StockPriceService);
+    jest.clearAllMocks();
+  });
+
+  describe('getPrice', () => {
+    it('캐시가 신선하면 isCached=true로 반환한다', async () => {
+      const fetchedAt = freshDate();
+      mockPrisma.stockPrice.findUnique.mockResolvedValue({
+        stockId: 's1',
+        price: 70000,
+        change: 500,
+        changeRate: 0.72,
+        fetchedAt,
+      });
+
+      const result = await service.getPrice('s1');
+
+      expect(result).not.toBeNull();
+      expect(result!.price).toBe(70000);
+      expect(result!.isCached).toBe(true);
+    });
+
+    it('캐시가 만료된 경우에도 isCached=true로 반환한다 (서비스 캐시 정책)', async () => {
+      const fetchedAt = staleDate();
+      mockPrisma.stockPrice.findUnique.mockResolvedValue({
+        stockId: 's1',
+        price: 68000,
+        change: -500,
+        changeRate: -0.73,
+        fetchedAt,
+      });
+
+      const result = await service.getPrice('s1');
+
+      // getPrice always returns isCached=true when record exists
+      expect(result).not.toBeNull();
+      expect(result!.isCached).toBe(true);
+    });
+
+    it('캐시 데이터가 없으면 null을 반환한다', async () => {
+      mockPrisma.stockPrice.findUnique.mockResolvedValue(null);
+
+      const result = await service.getPrice('s-unknown');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updatePrice', () => {
+    it('주가 데이터를 upsert한다', async () => {
+      const mockUpserted = {
+        stockId: 's1',
+        price: 70000,
+        change: 1000,
+        changeRate: 1.45,
+        fetchedAt: new Date(),
+      };
+      mockPrisma.stockPrice.upsert.mockResolvedValue(mockUpserted);
+
+      const result = await service.updatePrice('s1', 70000, 1000, 1.45);
+
+      expect(result).toEqual(mockUpserted);
+      expect(mockPrisma.stockPrice.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { stockId: 's1' },
+          update: expect.objectContaining({ price: 70000, change: 1000, changeRate: 1.45 }),
+          create: expect.objectContaining({ stockId: 's1', price: 70000 }),
+        }),
+      );
+    });
+  });
+
+  describe('bulkUpdatePrices', () => {
+    it('모두 성공하면 succeeded=전체 수, failed=0을 반환한다', async () => {
+      mockPrisma.stockPrice.upsert.mockResolvedValue({});
+
+      const result = await service.bulkUpdatePrices([
+        { stockId: 's1', price: 70000, change: 500, changeRate: 0.72 },
+        { stockId: 's2', price: 50000, change: -200, changeRate: -0.4 },
+      ]);
+
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+    });
+
+    it('일부 실패하면 성공/실패 건수를 올바르게 반환한다', async () => {
+      mockPrisma.stockPrice.upsert
+        .mockResolvedValueOnce({}) // s1 성공
+        .mockRejectedValueOnce(new Error('DB error')); // s2 실패
+
+      const result = await service.bulkUpdatePrices([
+        { stockId: 's1', price: 70000, change: 500, changeRate: 0.72 },
+        { stockId: 's2', price: 50000, change: -200, changeRate: -0.4 },
+      ]);
+
+      expect(result.succeeded).toBe(1);
+      expect(result.failed).toBe(1);
+    });
+
+    it('모두 실패해도 rejected를 throw하지 않고 카운트만 반환한다', async () => {
+      mockPrisma.stockPrice.upsert.mockRejectedValue(new Error('DB down'));
+
+      const result = await service.bulkUpdatePrices([
+        { stockId: 's1', price: 70000, change: 0, changeRate: 0 },
+        { stockId: 's2', price: 50000, change: 0, changeRate: 0 },
+      ]);
+
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(2);
+    });
+  });
+
+  describe('getPricesForStocks', () => {
+    it('stockIds 배열로 주가를 일괄 조회한다', async () => {
+      const mockPrices = [
+        { stockId: 's1', price: 70000, change: 500, changeRate: 0.72, fetchedAt: new Date() },
+        { stockId: 's2', price: 50000, change: -200, changeRate: -0.4, fetchedAt: new Date() },
+      ];
+      mockPrisma.stockPrice.findMany.mockResolvedValue(mockPrices);
+
+      const result = await service.getPricesForStocks(['s1', 's2']);
+
+      expect(result).toEqual(mockPrices);
+      expect(mockPrisma.stockPrice.findMany).toHaveBeenCalledWith({
+        where: { stockId: { in: ['s1', 's2'] } },
+      });
+    });
+
+    it('빈 배열을 전달하면 빈 배열을 반환한다', async () => {
+      mockPrisma.stockPrice.findMany.mockResolvedValue([]);
+
+      const result = await service.getPricesForStocks([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/stock/services/stock.service.spec.ts
+++ b/apps/api/src/stock/services/stock.service.spec.ts
@@ -1,0 +1,202 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { StockService } from './stock.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const mockPrisma = {
+  stock: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+  stockAccount: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+  },
+};
+
+const mockStock = {
+  id: 's1',
+  code: 'KRX001',
+  name: '삼성전자',
+  market: 'KRX',
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('StockService', () => {
+  let service: StockService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StockService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<StockService>(StockService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('검색어 없이 활성 종목 목록을 반환한다', async () => {
+      mockPrisma.stock.findMany.mockResolvedValue([mockStock]);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([mockStock]);
+      expect(mockPrisma.stock.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { isActive: true },
+          orderBy: { name: 'asc' },
+        }),
+      );
+    });
+
+    it('검색어가 있으면 OR 조건으로 name/code를 검색한다', async () => {
+      mockPrisma.stock.findMany.mockResolvedValue([mockStock]);
+
+      const result = await service.findAll('삼성');
+
+      expect(result).toEqual([mockStock]);
+      expect(mockPrisma.stock.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            isActive: true,
+            OR: [
+              { name: { contains: '삼성', mode: 'insensitive' } },
+              { code: { contains: '삼성', mode: 'insensitive' } },
+            ],
+          },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('존재하는 id로 조회 시 stockPrices를 포함하여 반환한다', async () => {
+      const stockWithPrices = { ...mockStock, stockPrices: [] };
+      mockPrisma.stock.findUnique.mockResolvedValue(stockWithPrices);
+
+      const result = await service.findOne('s1');
+
+      expect(result).toEqual(stockWithPrices);
+      expect(mockPrisma.stock.findUnique).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        include: { stockPrices: true },
+      });
+    });
+
+    it('존재하지 않는 id로 조회 시 NotFoundException을 던진다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('not-exist')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findByCode', () => {
+    it('존재하는 code로 조회 시 stockPrices를 포함하여 반환한다', async () => {
+      const stockWithPrices = { ...mockStock, stockPrices: [] };
+      mockPrisma.stock.findUnique.mockResolvedValue(stockWithPrices);
+
+      const result = await service.findByCode('KRX001');
+
+      expect(result).toEqual(stockWithPrices);
+      expect(mockPrisma.stock.findUnique).toHaveBeenCalledWith({
+        where: { code: 'KRX001' },
+        include: { stockPrices: true },
+      });
+    });
+
+    it('존재하지 않는 code로 조회 시 NotFoundException을 던진다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(null);
+
+      await expect(service.findByCode('INVALID')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('새로운 종목을 정상적으로 생성한다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(null);
+      mockPrisma.stock.create.mockResolvedValue(mockStock);
+
+      const result = await service.create({ code: 'KRX001', name: '삼성전자' });
+
+      expect(result).toEqual(mockStock);
+      expect(mockPrisma.stock.create).toHaveBeenCalledWith({
+        data: { code: 'KRX001', name: '삼성전자', market: 'KRX' },
+      });
+    });
+
+    it('market을 지정하면 해당 market으로 생성된다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(null);
+      mockPrisma.stock.create.mockResolvedValue({ ...mockStock, market: 'NYSE' });
+
+      await service.create({ code: 'AAPL', name: 'Apple', market: 'NYSE' });
+
+      expect(mockPrisma.stock.create).toHaveBeenCalledWith({
+        data: { code: 'AAPL', name: 'Apple', market: 'NYSE' },
+      });
+    });
+
+    it('이미 등록된 코드면 ConflictException을 던진다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+
+      await expect(
+        service.create({ code: 'KRX001', name: '삼성전자' }),
+      ).rejects.toThrow(ConflictException);
+
+      expect(mockPrisma.stock.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAccounts', () => {
+    it('userId에 해당하는 활성 계좌 목록을 반환한다', async () => {
+      const mockAccounts = [
+        { id: 'acc-1', userId: 'user-1', type: 'GENERAL', broker: '키움', alias: null, isActive: true, createdAt: new Date() },
+      ];
+      mockPrisma.stockAccount.findMany.mockResolvedValue(mockAccounts);
+
+      const result = await service.getAccounts('user-1');
+
+      expect(result).toEqual(mockAccounts);
+      expect(mockPrisma.stockAccount.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', isActive: true },
+        orderBy: { createdAt: 'asc' },
+      });
+    });
+  });
+
+  describe('createAccount', () => {
+    it('새로운 증권 계좌를 생성한다', async () => {
+      const mockAccount = {
+        id: 'acc-new',
+        userId: 'user-1',
+        type: 'ISA',
+        broker: '미래에셋',
+        alias: '연금ISA',
+        isActive: true,
+        createdAt: new Date(),
+      };
+      mockPrisma.stockAccount.create.mockResolvedValue(mockAccount);
+
+      const result = await service.createAccount('user-1', {
+        type: 'ISA',
+        broker: '미래에셋',
+        alias: '연금ISA',
+      });
+
+      expect(result).toEqual(mockAccount);
+      expect(mockPrisma.stockAccount.create).toHaveBeenCalledWith({
+        data: {
+          userId: 'user-1',
+          type: 'ISA',
+          broker: '미래에셋',
+          alias: '연금ISA',
+        },
+      });
+    });
+  });
+});

--- a/apps/api/src/stock/services/trade.service.spec.ts
+++ b/apps/api/src/stock/services/trade.service.spec.ts
@@ -1,0 +1,439 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { TradeService } from './trade.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FifoService } from './fifo.service';
+import { CreateTradeDto } from '../dto/create-trade.dto';
+import { UpdateTradeDto } from '../dto/update-trade.dto';
+import { QueryTradeDto } from '../dto/query-trade.dto';
+
+const USER_ID = 'user-001';
+const TRADE_ID = 'trade-001';
+const STOCK_ID = 'stock-001';
+const ACCOUNT_ID = 'account-001';
+
+const mockStock = {
+  id: STOCK_ID,
+  ticker: 'AAPL',
+  name: '애플',
+  market: 'NASDAQ',
+};
+
+const mockAccount = {
+  id: ACCOUNT_ID,
+  userId: USER_ID,
+  name: '키움증권',
+};
+
+const mockBuyTrade = {
+  id: TRADE_ID,
+  userId: USER_ID,
+  stockId: STOCK_ID,
+  accountId: ACCOUNT_ID,
+  type: 'BUY' as const,
+  tradeDate: new Date('2026-01-15'),
+  price: 50000,
+  quantity: 10,
+  reason: [],
+  memo: null,
+  stock: mockStock,
+  account: mockAccount,
+};
+
+const mockSellTrade = {
+  ...mockBuyTrade,
+  id: 'trade-002',
+  type: 'SELL' as const,
+  tradeDate: new Date('2026-03-15'),
+  price: 60000,
+  quantity: 5,
+};
+
+const mockPrisma = {
+  stock: {
+    findUnique: jest.fn(),
+  },
+  stockAccount: {
+    findFirst: jest.fn(),
+  },
+  trade: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    count: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    groupBy: jest.fn(),
+  },
+  realizedGain: {
+    count: jest.fn(),
+  },
+};
+
+const mockFifoService = {
+  calculateRealizedGain: jest.fn(),
+};
+
+describe('TradeService', () => {
+  let service: TradeService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: FifoService, useValue: mockFifoService },
+      ],
+    }).compile();
+
+    service = module.get<TradeService>(TradeService);
+  });
+
+  it('서비스가 정의된다', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────
+  describe('create - 거래 생성', () => {
+    const buyDto: CreateTradeDto = {
+      stockId: STOCK_ID,
+      accountId: ACCOUNT_ID,
+      type: 'BUY',
+      tradeDate: '2026-01-15',
+      price: 50000,
+      quantity: 10,
+    };
+
+    const sellDto: CreateTradeDto = {
+      stockId: STOCK_ID,
+      accountId: ACCOUNT_ID,
+      type: 'SELL',
+      tradeDate: '2026-03-15',
+      price: 60000,
+      quantity: 5,
+    };
+
+    describe('BUY 거래', () => {
+      it('종목과 계좌 검증 후 BUY 거래를 생성한다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+        mockPrisma.trade.create.mockResolvedValue(mockBuyTrade);
+
+        const result = await service.create(USER_ID, buyDto);
+
+        expect(mockPrisma.stock.findUnique).toHaveBeenCalledWith({
+          where: { id: STOCK_ID },
+        });
+        expect(mockPrisma.stockAccount.findFirst).toHaveBeenCalledWith({
+          where: { id: ACCOUNT_ID, userId: USER_ID },
+        });
+        expect(mockPrisma.trade.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              userId: USER_ID,
+              stockId: STOCK_ID,
+              accountId: ACCOUNT_ID,
+              type: 'BUY',
+              price: 50000,
+              quantity: 10,
+            }),
+            include: { stock: true, account: true },
+          }),
+        );
+        expect(mockFifoService.calculateRealizedGain).not.toHaveBeenCalled();
+        expect(result).toEqual(mockBuyTrade);
+      });
+
+      it('종목이 없으면 NotFoundException을 던진다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(null);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+
+        await expect(service.create(USER_ID, buyDto)).rejects.toThrow(
+          NotFoundException,
+        );
+        await expect(service.create(USER_ID, buyDto)).rejects.toThrow(
+          '종목을 찾을 수 없습니다.',
+        );
+      });
+
+      it('계좌가 없으면 NotFoundException을 던진다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(null);
+
+        await expect(service.create(USER_ID, buyDto)).rejects.toThrow(
+          NotFoundException,
+        );
+        await expect(service.create(USER_ID, buyDto)).rejects.toThrow(
+          '계좌를 찾을 수 없습니다.',
+        );
+      });
+    });
+
+    describe('SELL 거래', () => {
+      it('보유 수량 충분 시 SELL 거래를 생성하고 FIFO를 실행한다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+        // groupBy: BUY=10, SELL=0 → holding=10
+        mockPrisma.trade.groupBy.mockResolvedValue([
+          { type: 'BUY', _sum: { quantity: 10 } },
+        ]);
+        mockPrisma.trade.create.mockResolvedValue(mockSellTrade);
+        mockFifoService.calculateRealizedGain.mockResolvedValue(undefined);
+
+        const result = await service.create(USER_ID, sellDto);
+
+        expect(mockPrisma.trade.groupBy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            by: ['type'],
+            where: { userId: USER_ID, stockId: STOCK_ID, accountId: ACCOUNT_ID },
+            _sum: { quantity: true },
+          }),
+        );
+        expect(mockFifoService.calculateRealizedGain).toHaveBeenCalledWith(
+          mockSellTrade.id,
+        );
+        expect(result).toEqual(mockSellTrade);
+      });
+
+      it('보유 수량 부족 시 BadRequestException을 던진다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+        // holding = 2, want to sell 5
+        mockPrisma.trade.groupBy.mockResolvedValue([
+          { type: 'BUY', _sum: { quantity: 2 } },
+        ]);
+
+        await expect(service.create(USER_ID, sellDto)).rejects.toThrow(
+          BadRequestException,
+        );
+        expect(mockPrisma.trade.create).not.toHaveBeenCalled();
+      });
+
+      it('보유 수량이 0일 때 SELL 시도 시 BadRequestException을 던진다', async () => {
+        mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+        mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+        mockPrisma.trade.groupBy.mockResolvedValue([]);
+
+        await expect(service.create(USER_ID, sellDto)).rejects.toThrow(
+          BadRequestException,
+        );
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('findAll - 거래 목록 조회', () => {
+    it('필터 없이 전체 목록과 페이지 정보를 반환한다', async () => {
+      const trades = [mockBuyTrade];
+      mockPrisma.trade.findMany.mockResolvedValue(trades);
+      mockPrisma.trade.count.mockResolvedValue(1);
+
+      const query = new QueryTradeDto();
+      const result = await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: USER_ID },
+          include: { stock: true, account: true },
+          orderBy: { tradeDate: 'desc' },
+        }),
+      );
+      expect(result).toEqual({
+        data: trades,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+    });
+
+    it('stockId 필터를 적용한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.trade.count.mockResolvedValue(0);
+
+      const query = Object.assign(new QueryTradeDto(), { stockId: STOCK_ID });
+      await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: USER_ID, stockId: STOCK_ID },
+        }),
+      );
+    });
+
+    it('accountId 필터를 적용한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.trade.count.mockResolvedValue(0);
+
+      const query = Object.assign(new QueryTradeDto(), {
+        accountId: ACCOUNT_ID,
+      });
+      await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: USER_ID, accountId: ACCOUNT_ID },
+        }),
+      );
+    });
+
+    it('type 필터를 적용한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.trade.count.mockResolvedValue(0);
+
+      const query = Object.assign(new QueryTradeDto(), { type: 'BUY' as const });
+      await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: USER_ID, type: 'BUY' },
+        }),
+      );
+    });
+
+    it('날짜 범위 필터를 적용한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.trade.count.mockResolvedValue(0);
+
+      const query = Object.assign(new QueryTradeDto(), {
+        startDate: '2026-01-01',
+        endDate: '2026-12-31',
+      });
+      await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: USER_ID,
+            tradeDate: {
+              gte: new Date('2026-01-01'),
+              lte: new Date('2026-12-31'),
+            },
+          }),
+        }),
+      );
+    });
+
+    it('페이지네이션 skip/take를 올바르게 전달한다', async () => {
+      mockPrisma.trade.findMany.mockResolvedValue([]);
+      mockPrisma.trade.count.mockResolvedValue(0);
+
+      const query = Object.assign(new QueryTradeDto(), { page: 2, limit: 10 });
+      await service.findAll(USER_ID, query);
+
+      expect(mockPrisma.trade.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 10 }),
+      );
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('findOne - 거래 단건 조회', () => {
+    const tradeWithGains = {
+      ...mockBuyTrade,
+      realizedGainsAsSell: [],
+    };
+
+    it('거래를 반환한다', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(tradeWithGains);
+
+      const result = await service.findOne(USER_ID, TRADE_ID);
+
+      expect(mockPrisma.trade.findFirst).toHaveBeenCalledWith({
+        where: { id: TRADE_ID, userId: USER_ID },
+        include: {
+          stock: true,
+          account: true,
+          realizedGainsAsSell: true,
+        },
+      });
+      expect(result).toEqual(tradeWithGains);
+    });
+
+    it('거래가 없으면 NotFoundException을 던진다', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne(USER_ID, TRADE_ID)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findOne(USER_ID, TRADE_ID)).rejects.toThrow(
+        '거래 내역을 찾을 수 없습니다.',
+      );
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('update - 거래 수정', () => {
+    const tradeNoGains = { ...mockBuyTrade, realizedGainsAsSell: [] };
+    const tradeWithGains = {
+      ...mockSellTrade,
+      realizedGainsAsSell: [{ id: 'rg-001' }],
+    };
+
+    const updateDto: UpdateTradeDto = { price: 55000 };
+
+    it('FIFO 정산 이력이 없으면 거래를 수정한다', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(tradeNoGains);
+      const updated = { ...mockBuyTrade, price: 55000 };
+      mockPrisma.trade.update.mockResolvedValue(updated);
+
+      const result = await service.update(USER_ID, TRADE_ID, updateDto);
+
+      expect(mockPrisma.trade.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: TRADE_ID },
+          data: { price: 55000 },
+          include: { stock: true, account: true },
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it('FIFO 정산이 완료된 매도 거래는 수정할 수 없다 (BadRequestException)', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(tradeWithGains);
+
+      await expect(
+        service.update(USER_ID, mockSellTrade.id, updateDto),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.update(USER_ID, mockSellTrade.id, updateDto),
+      ).rejects.toThrow('FIFO 정산이 완료된 매도 거래는 수정할 수 없습니다.');
+      expect(mockPrisma.trade.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  describe('remove - 거래 삭제', () => {
+    const tradeNoGains = { ...mockBuyTrade, realizedGainsAsSell: [] };
+
+    it('FIFO 정산 이력이 없으면 거래를 삭제한다', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(tradeNoGains);
+      mockPrisma.realizedGain.count.mockResolvedValue(0);
+      mockPrisma.trade.delete.mockResolvedValue(mockBuyTrade);
+
+      const result = await service.remove(USER_ID, TRADE_ID);
+
+      expect(mockPrisma.realizedGain.count).toHaveBeenCalledWith({
+        where: { OR: [{ buyTradeId: TRADE_ID }, { sellTradeId: TRADE_ID }] },
+      });
+      expect(mockPrisma.trade.delete).toHaveBeenCalledWith({
+        where: { id: TRADE_ID },
+      });
+      expect(result).toEqual({ deleted: true });
+    });
+
+    it('FIFO 정산 이력이 있으면 삭제할 수 없다 (BadRequestException)', async () => {
+      mockPrisma.trade.findFirst.mockResolvedValue(tradeNoGains);
+      mockPrisma.realizedGain.count.mockResolvedValue(2);
+
+      await expect(service.remove(USER_ID, TRADE_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.remove(USER_ID, TRADE_ID)).rejects.toThrow(
+        'FIFO 정산 이력이 있는 거래는 삭제할 수 없습니다.',
+      );
+      expect(mockPrisma.trade.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/app/(main)/stocks/[stockId]/page.tsx
+++ b/apps/web/app/(main)/stocks/[stockId]/page.tsx
@@ -1,30 +1,178 @@
+'use client';
+
+import { use, useState } from 'react';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { TrendingUp } from 'lucide-react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { TrendingUp, ArrowLeft, Plus } from 'lucide-react';
+import { useStockDetail, useHoldings, useTrades, useStockAccounts, useStocks } from '@/hooks/use-stock';
+import { HoldingsTable } from '@/components/stock/holdings-table';
+import { TradeTable } from '@/components/stock/trade-table';
+import { TradeForm } from '@/components/stock/trade-form';
+import { AmountDisplay } from '@/components/common/amount-display';
+import type { Trade, CreateTradeDto, UpdateTradeDto } from '@/lib/api/stock';
+import { formatPercent } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 
 interface StockDetailPageProps {
   params: Promise<{ stockId: string }>;
 }
 
-export default async function StockDetailPage({ params }: StockDetailPageProps) {
-  const { stockId } = await params;
+export default function StockDetailPage({ params }: StockDetailPageProps) {
+  const { stockId } = use(params);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingTrade, setEditingTrade] = useState<Trade | null>(null);
+
+  const { stock, loading: stockLoading } = useStockDetail(stockId);
+  const { holdings } = useHoldings();
+  const { data: tradesData, loading: tradesLoading, create, update, remove } = useTrades({
+    stockId,
+    limit: 50,
+  });
+  const { stocks } = useStocks();
+  const { accounts } = useStockAccounts();
+
+  const thisHolding = holdings.find((h) => h.stockId === stockId);
+  const trades = tradesData?.data ?? [];
+
+  const handleEdit = (trade: Trade) => {
+    setEditingTrade(trade);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('이 매매 내역을 삭제하시겠습니까?')) return;
+    await remove(id);
+  };
+
+  const handleFormClose = (open: boolean) => {
+    setFormOpen(open);
+    if (!open) setEditingTrade(null);
+  };
+
+  const handleSubmit = async (dto: CreateTradeDto | UpdateTradeDto) => {
+    if (editingTrade) {
+      await update(editingTrade.id, dto as UpdateTradeDto);
+    } else {
+      await create(dto as CreateTradeDto);
+    }
+  };
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">종목 상세</h1>
+      <div className="flex items-center gap-3">
+        <Link href="/stocks" className={buttonVariants({ variant: 'ghost', size: 'icon' })}>
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <h1 className="text-2xl font-bold">종목 상세</h1>
+      </div>
 
+      {/* Stock Info Header */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <TrendingUp className="h-5 w-5" />
-            종목 정보 (ID: {stockId})
+            종목 정보
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            종목 상세 정보가 API 연동 후 표시됩니다.
-          </p>
+          {stockLoading ? (
+            <div className="text-muted-foreground text-sm">불러오는 중...</div>
+          ) : stock ? (
+            <div className="flex items-start justify-between">
+              <div>
+                <div className="text-xl font-bold">{stock.name}</div>
+                <div className="flex items-center gap-2 mt-1">
+                  <Badge variant="outline">{stock.code}</Badge>
+                  {stock.market && (
+                    <Badge variant="secondary">{stock.market}</Badge>
+                  )}
+                </div>
+              </div>
+              {thisHolding && (
+                <div className="text-right">
+                  <div className="text-sm text-muted-foreground">현재가</div>
+                  <AmountDisplay
+                    amount={thisHolding.currentPrice}
+                    className="text-lg font-semibold"
+                  />
+                  <div className={cn(
+                    'text-sm tabular-nums',
+                    thisHolding.unrealizedGainRate > 0 ? 'text-gain' :
+                    thisHolding.unrealizedGainRate < 0 ? 'text-loss' : 'text-muted-foreground',
+                  )}>
+                    {formatPercent(thisHolding.unrealizedGainRate)}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-muted-foreground text-sm">종목 정보를 찾을 수 없습니다.</div>
+          )}
         </CardContent>
       </Card>
+
+      {/* Holdings for this stock */}
+      {thisHolding && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">보유 현황</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <HoldingsTable holdings={[thisHolding]} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Trade History for this stock */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">
+            매매 내역
+            {trades.length > 0 && (
+              <span className="text-sm font-normal text-muted-foreground ml-1">
+                ({trades.length}건)
+              </span>
+            )}
+          </CardTitle>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setEditingTrade(null);
+              setFormOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            매매 추가
+          </Button>
+        </CardHeader>
+        <CardContent className="p-0">
+          {tradesLoading ? (
+            <div className="py-12 text-center text-muted-foreground text-sm">
+              불러오는 중...
+            </div>
+          ) : (
+            <TradeTable
+              trades={trades}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Trade Form Dialog */}
+      <TradeForm
+        open={formOpen}
+        onOpenChange={handleFormClose}
+        stocks={stocks}
+        accounts={accounts}
+        trade={editingTrade}
+        defaultStockId={stockId}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }

--- a/apps/web/app/(main)/stocks/accounts/[accountId]/page.tsx
+++ b/apps/web/app/(main)/stocks/accounts/[accountId]/page.tsx
@@ -1,28 +1,169 @@
+'use client';
+
+import { use, useState } from 'react';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Building2 } from 'lucide-react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Building2, ArrowLeft, TrendingUp, BarChart3 } from 'lucide-react';
+import { ACCOUNT_TYPES } from '@my-wallet/shared';
+import type { AccountType } from '@my-wallet/shared';
+import { useStockAccounts, useHoldings, usePerformance } from '@/hooks/use-stock';
+import { HoldingsTable } from '@/components/stock/holdings-table';
+import { PerformanceChart } from '@/components/stock/performance-chart';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { formatPercent } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 
 interface AccountDetailPageProps {
   params: Promise<{ accountId: string }>;
 }
 
-export default async function AccountDetailPage({ params }: AccountDetailPageProps) {
-  const { accountId } = await params;
+export default function AccountDetailPage({ params }: AccountDetailPageProps) {
+  const { accountId } = use(params);
+  const currentYear = new Date().getFullYear();
+  const [year, setYear] = useState(currentYear);
+
+  const { accounts, loading: accountsLoading } = useStockAccounts();
+  const { holdings, loading: holdingsLoading } = useHoldings(accountId);
+  const { performance, loading: perfLoading } = usePerformance(year, accountId);
+
+  const account = accounts.find((a) => a.id === accountId);
+
+  const totalUnrealizedGain = holdings.reduce((sum, h) => sum + h.unrealizedGain, 0);
+  const totalEvaluation = holdings.reduce((sum, h) => sum + h.evaluation, 0);
+  const totalInvested = holdings.reduce((sum, h) => sum + h.invested, 0);
+  const totalRealizedGain = performance.reduce((sum, p) => sum + p.realizedGain, 0);
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">계좌 상세</h1>
+      <div className="flex items-center gap-3">
+        <Link href="/stocks" className={buttonVariants({ variant: 'ghost', size: 'icon' })}>
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <h1 className="text-2xl font-bold">계좌 상세</h1>
+      </div>
 
+      {/* Account Info */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />
-            계좌 정보 (ID: {accountId})
+            계좌 정보
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            계좌별 보유 종목 및 성과 데이터가 API 연동 후 표시됩니다.
-          </p>
+          {accountsLoading ? (
+            <div className="text-muted-foreground text-sm">불러오는 중...</div>
+          ) : account ? (
+            <div className="flex items-start justify-between">
+              <div>
+                <div className="text-xl font-bold">
+                  {account.alias ?? account.broker}
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <Badge variant="outline">
+                    {ACCOUNT_TYPES[account.type as AccountType]}
+                  </Badge>
+                  <Badge variant="secondary">{account.broker}</Badge>
+                </div>
+              </div>
+              <div className="text-right space-y-1">
+                <div>
+                  <div className="text-xs text-muted-foreground">평가금액</div>
+                  <AmountDisplay amount={totalEvaluation} className="font-semibold" />
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">미실현 손익</div>
+                  <span className={cn(
+                    'font-semibold tabular-nums text-sm',
+                    totalUnrealizedGain > 0 ? 'text-gain' :
+                    totalUnrealizedGain < 0 ? 'text-loss' : 'text-foreground',
+                  )}>
+                    <AmountDisplay amount={totalUnrealizedGain} showSign />
+                    {totalInvested > 0 && (
+                      <span className="ml-1 text-xs">
+                        ({formatPercent(((totalEvaluation - totalInvested) / totalInvested) * 100)})
+                      </span>
+                    )}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="text-muted-foreground text-sm">계좌 정보를 찾을 수 없습니다.</div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Holdings */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="h-5 w-5" />
+            보유 종목
+            {holdings.length > 0 && (
+              <span className="text-sm font-normal text-muted-foreground ml-1">
+                ({holdings.length}종목)
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {holdingsLoading ? (
+            <div className="py-12 text-center text-muted-foreground text-sm">
+              불러오는 중...
+            </div>
+          ) : (
+            <HoldingsTable holdings={holdings} />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Performance Chart */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            월별 실현 손익
+            <span className={cn(
+              'text-sm font-normal ml-1',
+              totalRealizedGain > 0 ? 'text-gain' :
+              totalRealizedGain < 0 ? 'text-loss' : 'text-muted-foreground',
+            )}>
+              (연간 합계: <AmountDisplay amount={totalRealizedGain} showSign />)
+            </span>
+          </CardTitle>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={year <= currentYear - 5}
+              onClick={() => setYear((y) => y - 1)}
+              className="h-7 w-7 p-0"
+            >
+              ‹
+            </Button>
+            <span className="text-sm font-medium w-12 text-center">{year}년</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={year >= currentYear}
+              onClick={() => setYear((y) => y + 1)}
+              className="h-7 w-7 p-0"
+            >
+              ›
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {perfLoading ? (
+            <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+              불러오는 중...
+            </div>
+          ) : (
+            <PerformanceChart data={performance} />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/apps/web/app/(main)/stocks/page.tsx
+++ b/apps/web/app/(main)/stocks/page.tsx
@@ -1,51 +1,202 @@
+'use client';
+
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { TrendingUp } from 'lucide-react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { TrendingUp, Plus, Building2 } from 'lucide-react';
+import { usePortfolioSummary } from '@/hooks/use-stock';
+import { useHoldings } from '@/hooks/use-stock';
+import { useStockAccounts } from '@/hooks/use-stock';
+import { HoldingsTable } from '@/components/stock/holdings-table';
+import { AccountForm } from '@/components/stock/account-form';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { formatPercent } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 
 export default function StocksPage() {
+  const [selectedAccountId, setSelectedAccountId] = useState<string | undefined>(undefined);
+  const [accountFormOpen, setAccountFormOpen] = useState(false);
+
+  const { accounts, loading: accountsLoading, create: createAccount } = useStockAccounts();
+  const { summary, loading: summaryLoading } = usePortfolioSummary(selectedAccountId);
+  const { holdings, loading: holdingsLoading } = useHoldings(selectedAccountId);
+
+  const gainClass = (value: number) =>
+    cn(
+      'text-2xl font-bold tabular-nums',
+      value > 0 ? 'text-gain' : value < 0 ? 'text-loss' : 'text-foreground',
+    );
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">주식 포트폴리오</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">주식 포트폴리오</h1>
+        <div className="flex items-center gap-2">
+          <Link href="/stocks/trades" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
+            매매 내역
+          </Link>
+          <Button variant="outline" size="sm" onClick={() => setAccountFormOpen(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            계좌 추가
+          </Button>
+        </div>
+      </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
+      {/* Account Selector */}
+      <div className="flex items-center gap-3">
+        <Building2 className="h-4 w-4 text-muted-foreground" />
+        <Select
+          value={selectedAccountId ?? '__all__'}
+          onValueChange={(v) => setSelectedAccountId(v === '__all__' ? undefined : v)}
+        >
+          <SelectTrigger className="w-56">
+            <SelectValue placeholder="전체 계좌" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">전체 계좌</SelectItem>
+            {accounts.map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.alias ?? `${a.broker}`}{' '}
+                <span className="text-muted-foreground text-xs">({a.type})</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {selectedAccountId && (
+          <Link
+            href={`/stocks/accounts/${selectedAccountId}`}
+            className={buttonVariants({ variant: 'ghost', size: 'sm' }) + ' text-xs text-muted-foreground'}
+          >
+            계좌 상세 보기
+          </Link>
+        )}
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">총 평가 금액</CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              총 평가금액
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
+            {summaryLoading ? (
+              <div className="text-2xl font-bold text-muted-foreground">-</div>
+            ) : summary ? (
+              <AmountDisplay amount={summary.totalEvaluation} className="text-2xl font-bold" />
+            ) : (
+              <div className="text-2xl font-bold text-muted-foreground">0원</div>
+            )}
           </CardContent>
         </Card>
+
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">총 투자 금액</CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              총 투자금액
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
+            {summaryLoading ? (
+              <div className="text-2xl font-bold text-muted-foreground">-</div>
+            ) : summary ? (
+              <AmountDisplay amount={summary.totalInvested} className="text-2xl font-bold" />
+            ) : (
+              <div className="text-2xl font-bold text-muted-foreground">0원</div>
+            )}
           </CardContent>
         </Card>
+
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">미실현 손익</CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              미실현 손익
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
+            {summaryLoading ? (
+              <div className="text-2xl font-bold text-muted-foreground">-</div>
+            ) : summary ? (
+              <div>
+                <AmountDisplay
+                  amount={summary.totalUnrealizedGain}
+                  showSign
+                  className={gainClass(summary.totalUnrealizedGain)}
+                />
+                <div className={cn('text-sm tabular-nums mt-0.5',
+                  summary.totalUnrealizedGainRate > 0 ? 'text-gain' :
+                  summary.totalUnrealizedGainRate < 0 ? 'text-loss' : 'text-muted-foreground'
+                )}>
+                  {formatPercent(summary.totalUnrealizedGainRate)}
+                </div>
+              </div>
+            ) : (
+              <div className="text-2xl font-bold text-muted-foreground">0원</div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              실현 손익
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {summaryLoading ? (
+              <div className="text-2xl font-bold text-muted-foreground">-</div>
+            ) : summary ? (
+              <AmountDisplay
+                amount={summary.totalRealizedGain}
+                showSign
+                className={gainClass(summary.totalRealizedGain)}
+              />
+            ) : (
+              <div className="text-2xl font-bold text-muted-foreground">0원</div>
+            )}
           </CardContent>
         </Card>
       </div>
 
+      {/* Holdings Table */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <TrendingUp className="h-5 w-5" />
             보유 종목
+            {holdings.length > 0 && (
+              <span className="text-sm font-normal text-muted-foreground ml-1">
+                ({holdings.length}종목)
+              </span>
+            )}
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            보유 종목 목록이 API 연동 후 표시됩니다.
-          </p>
+        <CardContent className="p-0">
+          {holdingsLoading ? (
+            <div className="py-12 text-center text-muted-foreground text-sm">
+              불러오는 중...
+            </div>
+          ) : (
+            <HoldingsTable holdings={holdings} />
+          )}
         </CardContent>
       </Card>
+
+      {/* Account Form Dialog */}
+      <AccountForm
+        open={accountFormOpen}
+        onOpenChange={setAccountFormOpen}
+        onSubmit={createAccount}
+      />
     </div>
   );
 }

--- a/apps/web/app/(main)/stocks/trades/page.tsx
+++ b/apps/web/app/(main)/stocks/trades/page.tsx
@@ -1,26 +1,262 @@
+'use client';
+
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ArrowLeftRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { ArrowLeftRight, Plus, Search } from 'lucide-react';
+import type { TradeType } from '@my-wallet/shared';
+import { useTrades, useStocks, useStockAccounts } from '@/hooks/use-stock';
+import { TradeTable } from '@/components/stock/trade-table';
+import { TradeForm } from '@/components/stock/trade-form';
+import type { Trade, CreateTradeDto, UpdateTradeDto } from '@/lib/api/stock';
+
+const PAGE_SIZE = 20;
 
 export default function StockTradesPage() {
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingTrade, setEditingTrade] = useState<Trade | null>(null);
+
+  // Filters
+  const [stockSearch, setStockSearch] = useState('');
+  const [filterAccountId, setFilterAccountId] = useState('');
+  const [filterType, setFilterType] = useState<TradeType | ''>('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [page, setPage] = useState(1);
+
+  const { stocks } = useStocks();
+  const { accounts } = useStockAccounts();
+
+  // Find stockId from search
+  const matchedStock = stockSearch
+    ? stocks.find(
+        (s) =>
+          s.name.includes(stockSearch) || s.code.includes(stockSearch),
+      )
+    : undefined;
+
+  const { data, loading, error, create, update, remove } = useTrades({
+    stockId: matchedStock?.id,
+    accountId: filterAccountId || undefined,
+    type: filterType || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    page,
+    limit: PAGE_SIZE,
+  });
+
+  const trades = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  const handleCreate = async (dto: CreateTradeDto | UpdateTradeDto) => {
+    await create(dto as CreateTradeDto);
+  };
+
+  const handleUpdate = async (dto: CreateTradeDto | UpdateTradeDto) => {
+    if (editingTrade) {
+      await update(editingTrade.id, dto as UpdateTradeDto);
+    }
+  };
+
+  const handleEdit = (trade: Trade) => {
+    setEditingTrade(trade);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('이 매매 내역을 삭제하시겠습니까?')) return;
+    await remove(id);
+  };
+
+  const handleOpenCreate = () => {
+    setEditingTrade(null);
+    setFormOpen(true);
+  };
+
+  const handleFormClose = (open: boolean) => {
+    setFormOpen(open);
+    if (!open) setEditingTrade(null);
+  };
+
+  const resetFilters = () => {
+    setStockSearch('');
+    setFilterAccountId('');
+    setFilterType('');
+    setStartDate('');
+    setEndDate('');
+    setPage(1);
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">매매 내역</h1>
+        <Button onClick={handleOpenCreate} size="sm">
+          <Plus className="h-4 w-4 mr-1" />
+          매매 추가
+        </Button>
       </div>
 
+      {/* Filters */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Search className="h-4 w-4" />
+            필터
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">종목 검색</label>
+              <Input
+                value={stockSearch}
+                onChange={(e) => { setStockSearch(e.target.value); setPage(1); }}
+                placeholder="종목명 또는 코드"
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">계좌</label>
+              <Select
+                value={filterAccountId || '__all__'}
+                onValueChange={(v) => {
+                  setFilterAccountId(v === '__all__' ? '' : v);
+                  setPage(1);
+                }}
+              >
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue placeholder="전체" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">전체</SelectItem>
+                  {accounts.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.alias ?? a.broker}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">유형</label>
+              <Select
+                value={filterType || '__all__'}
+                onValueChange={(v) => {
+                  setFilterType(v === '__all__' ? '' : v as TradeType);
+                  setPage(1);
+                }}
+              >
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue placeholder="전체" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">전체</SelectItem>
+                  <SelectItem value="BUY">매수</SelectItem>
+                  <SelectItem value="SELL">매도</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">시작일</label>
+              <Input
+                type="date"
+                value={startDate}
+                onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">종료일</label>
+              <Input
+                type="date"
+                value={endDate}
+                onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="flex items-end">
+              <Button variant="outline" size="sm" onClick={resetFilters} className="h-8 w-full">
+                초기화
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Trade List */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <ArrowLeftRight className="h-5 w-5" />
             매매 목록
+            {total > 0 && (
+              <span className="text-sm font-normal text-muted-foreground ml-1">
+                (총 {total.toLocaleString('ko-KR')}건)
+              </span>
+            )}
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            매매 내역이 API 연동 후 표시됩니다.
-          </p>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="py-12 text-center text-muted-foreground text-sm">
+              불러오는 중...
+            </div>
+          ) : error ? (
+            <div className="py-12 text-center text-destructive text-sm">{error}</div>
+          ) : (
+            <TradeTable
+              trades={trades}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          )}
         </CardContent>
       </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            이전
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {page} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            다음
+          </Button>
+        </div>
+      )}
+
+      {/* Trade Form Dialog */}
+      <TradeForm
+        open={formOpen}
+        onOpenChange={handleFormClose}
+        stocks={stocks}
+        accounts={accounts}
+        trade={editingTrade}
+        onSubmit={editingTrade ? handleUpdate : handleCreate}
+      />
     </div>
   );
 }

--- a/apps/web/components/stock/account-form.tsx
+++ b/apps/web/components/stock/account-form.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { AccountType } from '@my-wallet/shared';
+import { ACCOUNT_TYPES, BROKERS } from '@my-wallet/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import type { CreateStockAccountDto } from '@/lib/api/stock';
+
+interface AccountFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (dto: CreateStockAccountDto) => Promise<void>;
+}
+
+const ACCOUNT_TYPE_OPTIONS = Object.entries(ACCOUNT_TYPES) as [AccountType, string][];
+
+export function AccountForm({ open, onOpenChange, onSubmit }: AccountFormProps) {
+  const [type, setType] = useState<AccountType>('GENERAL');
+  const [broker, setBroker] = useState('');
+  const [alias, setAlias] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setType('GENERAL');
+      setBroker('');
+      setAlias('');
+      setError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!broker) { setError('증권사를 선택해주세요.'); return; }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const dto: CreateStockAccountDto = {
+        type,
+        broker,
+        alias: alias.trim() || undefined,
+      };
+      await onSubmit(dto);
+      onOpenChange(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '계좌 생성에 실패했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>계좌 추가</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Account Type */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">계좌 유형</label>
+            <Select value={type} onValueChange={(v) => setType(v as AccountType)}>
+              <SelectTrigger>
+                <SelectValue placeholder="계좌 유형 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCOUNT_TYPE_OPTIONS.map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Broker */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">증권사</label>
+            <Select value={broker} onValueChange={setBroker}>
+              <SelectTrigger>
+                <SelectValue placeholder="증권사 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {BROKERS.map((b) => (
+                  <SelectItem key={b} value={b}>
+                    {b}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Alias */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">계좌 별칭 (선택)</label>
+            <Input
+              value={alias}
+              onChange={(e) => setAlias(e.target.value)}
+              placeholder="예: 키움 ISA"
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '저장 중...' : '추가'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/stock/holdings-table.tsx
+++ b/apps/web/components/stock/holdings-table.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import Link from 'next/link';
+import type { HoldingItem } from '@my-wallet/shared';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { formatAmount, formatPercent } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+
+interface HoldingsTableProps {
+  holdings: HoldingItem[];
+}
+
+export function HoldingsTable({ holdings }: HoldingsTableProps) {
+  if (holdings.length === 0) {
+    return (
+      <div className="py-12 text-center text-muted-foreground text-sm">
+        보유 종목이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>종목명</TableHead>
+          <TableHead className="text-right">수량</TableHead>
+          <TableHead className="text-right">평균단가</TableHead>
+          <TableHead className="text-right">현재가</TableHead>
+          <TableHead className="text-right">평가금액</TableHead>
+          <TableHead className="text-right">손익 (수익률)</TableHead>
+          <TableHead className="text-right">비중</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {holdings.map((item) => {
+          const isProfit = item.unrealizedGain > 0;
+          const isLoss = item.unrealizedGain < 0;
+          const gainColorClass = isProfit
+            ? 'text-gain'
+            : isLoss
+              ? 'text-loss'
+              : 'text-foreground';
+
+          return (
+            <TableRow key={item.stockId}>
+              <TableCell>
+                <Link
+                  href={`/stocks/${item.stockId}`}
+                  className="font-medium hover:underline"
+                >
+                  {item.stockName}
+                </Link>
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  {item.stockCode}
+                </span>
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {item.quantity.toLocaleString('ko-KR')}주
+              </TableCell>
+              <TableCell className="text-right">
+                <AmountDisplay amount={item.avgBuyPrice} />
+              </TableCell>
+              <TableCell className="text-right">
+                <AmountDisplay amount={item.currentPrice} />
+              </TableCell>
+              <TableCell className="text-right">
+                <AmountDisplay amount={item.evaluation} />
+              </TableCell>
+              <TableCell className="text-right">
+                <span className={cn('tabular-nums', gainColorClass)}>
+                  {formatAmount(item.unrealizedGain)}
+                </span>
+                <span className={cn('ml-1 text-xs tabular-nums', gainColorClass)}>
+                  ({formatPercent(item.unrealizedGainRate)})
+                </span>
+              </TableCell>
+              <TableCell className="text-right tabular-nums text-muted-foreground">
+                {item.weight.toFixed(1)}%
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/components/stock/performance-chart.tsx
+++ b/apps/web/components/stock/performance-chart.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import type { PerformanceItem } from '@my-wallet/shared';
+
+interface PerformanceChartProps {
+  data: PerformanceItem[];
+}
+
+function formatKRW(value: number): string {
+  if (Math.abs(value) >= 10000000) {
+    return `${(value / 10000000).toFixed(1)}천만`;
+  }
+  if (Math.abs(value) >= 10000) {
+    return `${Math.round(value / 10000)}만`;
+  }
+  return new Intl.NumberFormat('ko-KR').format(value);
+}
+
+function formatMonth(month: string): string {
+  // month format: "2024-01"
+  const parts = month.split('-');
+  if (parts.length === 2) {
+    return `${parts[1]}월`;
+  }
+  return month;
+}
+
+export function PerformanceChart({ data }: PerformanceChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        표시할 성과 데이터가 없습니다.
+      </div>
+    );
+  }
+
+  const chartData = data.map((item) => ({
+    month: formatMonth(item.month),
+    실현손익: item.realizedGain,
+    거래횟수: item.tradeCount,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis
+          dataKey="month"
+          tick={{ fontSize: 12 }}
+          className="text-muted-foreground"
+        />
+        <YAxis
+          tickFormatter={formatKRW}
+          tick={{ fontSize: 11 }}
+          className="text-muted-foreground"
+        />
+        <Tooltip
+          formatter={(value: number, name: string) => {
+            if (name === '실현손익') {
+              return [new Intl.NumberFormat('ko-KR').format(value) + '원', name];
+            }
+            return [value + '회', name];
+          }}
+          labelStyle={{ fontWeight: 600 }}
+        />
+        <Bar dataKey="실현손익" radius={[3, 3, 0, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={entry.실현손익 >= 0 ? '#ef4444' : '#3b82f6'}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/components/stock/trade-form.tsx
+++ b/apps/web/components/stock/trade-form.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { TradeType } from '@my-wallet/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import type {
+  Trade,
+  StockAccount,
+  Stock,
+  CreateTradeDto,
+  UpdateTradeDto,
+} from '@/lib/api/stock';
+
+interface TradeFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stocks: Stock[];
+  accounts: StockAccount[];
+  trade?: Trade | null;
+  defaultStockId?: string;
+  onSubmit: (dto: CreateTradeDto | UpdateTradeDto) => Promise<void>;
+}
+
+const TYPE_OPTIONS: TradeType[] = ['BUY', 'SELL'];
+const TYPE_LABELS: Record<TradeType, string> = { BUY: '매수', SELL: '매도' };
+
+const REASON_OPTIONS = [
+  '가치 투자',
+  '성장주',
+  '배당',
+  '모멘텀',
+  '단기 트레이딩',
+  '분할 매수',
+  '목표가 달성',
+  '손절',
+  '포트폴리오 리밸런싱',
+  '기타',
+];
+
+export function TradeForm({
+  open,
+  onOpenChange,
+  stocks,
+  accounts,
+  trade,
+  defaultStockId,
+  onSubmit,
+}: TradeFormProps) {
+  const [stockId, setStockId] = useState('');
+  const [stockSearch, setStockSearch] = useState('');
+  const [accountId, setAccountId] = useState('');
+  const [type, setType] = useState<TradeType>('BUY');
+  const [tradeDate, setTradeDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [price, setPrice] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [reasons, setReasons] = useState<string[]>([]);
+  const [memo, setMemo] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (trade) {
+      setStockId(trade.stockId);
+      setAccountId(trade.accountId);
+      setType(trade.type);
+      setTradeDate(trade.tradeDate.slice(0, 10));
+      setPrice(String(trade.price));
+      setQuantity(String(trade.quantity));
+      setReasons(trade.reason ?? []);
+      setMemo(trade.memo ?? '');
+    } else {
+      setStockId(defaultStockId ?? '');
+      setAccountId('');
+      setType('BUY');
+      setTradeDate(new Date().toISOString().slice(0, 10));
+      setPrice('');
+      setQuantity('');
+      setReasons([]);
+      setMemo('');
+    }
+    setStockSearch('');
+    setError(null);
+  }, [trade, open, defaultStockId]);
+
+  const filteredStocks = stockSearch
+    ? stocks.filter(
+        (s) =>
+          s.name.includes(stockSearch) || s.code.includes(stockSearch),
+      )
+    : stocks;
+
+  const toggleReason = (reason: string) => {
+    setReasons((prev) =>
+      prev.includes(reason) ? prev.filter((r) => r !== reason) : [...prev, reason],
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stockId) { setError('종목을 선택해주세요.'); return; }
+    if (!accountId) { setError('계좌를 선택해주세요.'); return; }
+    const priceNum = parseInt(price.replace(/,/g, ''), 10);
+    if (isNaN(priceNum) || priceNum <= 0) { setError('유효한 단가를 입력해주세요.'); return; }
+    const quantityNum = parseInt(quantity.replace(/,/g, ''), 10);
+    if (isNaN(quantityNum) || quantityNum <= 0) { setError('유효한 수량을 입력해주세요.'); return; }
+    if (!tradeDate) { setError('날짜를 선택해주세요.'); return; }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (trade) {
+        const dto: UpdateTradeDto = {
+          tradeDate,
+          price: priceNum,
+          quantity: quantityNum,
+          reason: reasons.length > 0 ? reasons : undefined,
+          memo: memo.trim() || undefined,
+        };
+        await onSubmit(dto);
+      } else {
+        const dto: CreateTradeDto = {
+          stockId,
+          accountId,
+          type,
+          tradeDate,
+          price: priceNum,
+          quantity: quantityNum,
+          reason: reasons.length > 0 ? reasons : undefined,
+          memo: memo.trim() || undefined,
+        };
+        await onSubmit(dto);
+      }
+      onOpenChange(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '저장에 실패했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{trade ? '매매 수정' : '매매 추가'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Stock */}
+          {!trade && (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">종목</label>
+              <Input
+                value={stockSearch}
+                onChange={(e) => setStockSearch(e.target.value)}
+                placeholder="종목명 또는 코드 검색"
+                className="mb-1"
+              />
+              <Select value={stockId} onValueChange={setStockId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="종목 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {filteredStocks.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name} ({s.code})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Account */}
+          {!trade && (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">계좌</label>
+              <Select value={accountId} onValueChange={setAccountId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="계좌 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {accounts.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.alias ?? `${a.broker}`} ({a.type})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Type */}
+          {!trade && (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">유형</label>
+              <Select value={type} onValueChange={(v) => setType(v as TradeType)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="유형 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TYPE_OPTIONS.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      {TYPE_LABELS[t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Trade Date */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">거래일</label>
+            <Input
+              type="date"
+              value={tradeDate}
+              onChange={(e) => setTradeDate(e.target.value)}
+            />
+          </div>
+
+          {/* Price */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">단가 (원)</label>
+            <Input
+              type="number"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              placeholder="0"
+              min={1}
+            />
+          </div>
+
+          {/* Quantity */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">수량 (주)</label>
+            <Input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              placeholder="0"
+              min={1}
+            />
+          </div>
+
+          {/* Total preview */}
+          {price && quantity && (
+            <div className="text-sm text-muted-foreground">
+              총금액:{' '}
+              <span className="font-medium text-foreground">
+                {new Intl.NumberFormat('ko-KR').format(
+                  (parseInt(price) || 0) * (parseInt(quantity) || 0),
+                )}
+                원
+              </span>
+            </div>
+          )}
+
+          {/* Reasons */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">매매 사유 (선택)</label>
+            <div className="flex flex-wrap gap-2">
+              {REASON_OPTIONS.map((reason) => (
+                <button
+                  key={reason}
+                  type="button"
+                  onClick={() => toggleReason(reason)}
+                  className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${
+                    reasons.includes(reason)
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-background text-foreground border-border hover:bg-muted'
+                  }`}
+                >
+                  {reason}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Memo */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">메모 (선택)</label>
+            <Input
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              placeholder="메모"
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '저장 중...' : trade ? '수정' : '추가'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/stock/trade-table.tsx
+++ b/apps/web/components/stock/trade-table.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import type { TradeType } from '@my-wallet/shared';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { AmountDisplay } from '@/components/common/amount-display';
+import type { Trade } from '@/lib/api/stock';
+import { Pencil, Trash2 } from 'lucide-react';
+
+interface TradeTableProps {
+  trades: Trade[];
+  onEdit: (trade: Trade) => void;
+  onDelete: (id: string) => void;
+}
+
+const TYPE_LABELS: Record<TradeType, string> = {
+  BUY: '매수',
+  SELL: '매도',
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export function TradeTable({ trades, onEdit, onDelete }: TradeTableProps) {
+  if (trades.length === 0) {
+    return (
+      <div className="py-12 text-center text-muted-foreground text-sm">
+        매매 내역이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>날짜</TableHead>
+          <TableHead>종목</TableHead>
+          <TableHead>계좌</TableHead>
+          <TableHead>유형</TableHead>
+          <TableHead className="text-right">단가</TableHead>
+          <TableHead className="text-right">수량</TableHead>
+          <TableHead className="text-right">총금액</TableHead>
+          <TableHead>사유</TableHead>
+          <TableHead className="w-20"></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {trades.map((trade) => (
+          <TableRow key={trade.id}>
+            <TableCell className="text-muted-foreground whitespace-nowrap">
+              {formatDate(trade.tradeDate)}
+            </TableCell>
+            <TableCell>
+              <span className="font-medium">{trade.stock?.name ?? '-'}</span>
+              {trade.stock?.code && (
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  {trade.stock.code}
+                </span>
+              )}
+            </TableCell>
+            <TableCell className="text-sm text-muted-foreground">
+              {trade.account
+                ? (trade.account.alias ?? `${trade.account.broker}`)
+                : '-'}
+            </TableCell>
+            <TableCell>
+              <Badge
+                variant={trade.type === 'BUY' ? 'default' : 'destructive'}
+              >
+                {TYPE_LABELS[trade.type]}
+              </Badge>
+            </TableCell>
+            <TableCell className="text-right">
+              <AmountDisplay amount={trade.price} />
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {trade.quantity.toLocaleString('ko-KR')}주
+            </TableCell>
+            <TableCell className="text-right">
+              <AmountDisplay amount={trade.totalAmount} />
+            </TableCell>
+            <TableCell className="text-sm text-muted-foreground max-w-32 truncate">
+              {trade.reason && trade.reason.length > 0
+                ? trade.reason.join(', ')
+                : '-'}
+            </TableCell>
+            <TableCell>
+              <div className="flex items-center gap-1 justify-end">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onEdit(trade)}
+                  aria-label="수정"
+                  className="h-7 w-7"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onDelete(trade.id)}
+                  aria-label="삭제"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/hooks/use-stock.ts
+++ b/apps/web/hooks/use-stock.ts
@@ -1,0 +1,354 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { HoldingItem, PortfolioSummary, PerformanceItem } from '@my-wallet/shared';
+import {
+  fetchPortfolioSummary,
+  fetchHoldings,
+  fetchPerformance,
+  fetchTrades,
+  fetchStocks,
+  fetchStockAccounts,
+  fetchStock,
+  fetchTradeRealizedGains,
+  createTrade,
+  updateTrade,
+  deleteTrade,
+  createStockAccount,
+  type Trade,
+  type Stock,
+  type StockAccount,
+  type TradeFilters,
+  type CreateTradeDto,
+  type UpdateTradeDto,
+  type CreateStockAccountDto,
+  type RealizedGain,
+} from '@/lib/api/stock';
+import type { PaginatedResponse } from '@my-wallet/shared';
+
+// ─── usePortfolioSummary ──────────────────────────────────────────────────────
+
+interface UsePortfolioSummaryReturn {
+  summary: PortfolioSummary | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function usePortfolioSummary(accountId?: string): UsePortfolioSummaryReturn {
+  const [summary, setSummary] = useState<PortfolioSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchPortfolioSummary(accountId)
+      .then((res) => {
+        if (!cancelled) setSummary(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '포트폴리오 요약을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [accountId, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { summary, loading, error, refetch };
+}
+
+// ─── useHoldings ──────────────────────────────────────────────────────────────
+
+interface UseHoldingsReturn {
+  holdings: HoldingItem[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useHoldings(accountId?: string): UseHoldingsReturn {
+  const [holdings, setHoldings] = useState<HoldingItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchHoldings(accountId)
+      .then((res) => {
+        if (!cancelled) setHoldings(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '보유 종목을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [accountId, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { holdings, loading, error, refetch };
+}
+
+// ─── usePerformance ───────────────────────────────────────────────────────────
+
+interface UsePerformanceReturn {
+  performance: PerformanceItem[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function usePerformance(year: number, accountId?: string): UsePerformanceReturn {
+  const [performance, setPerformance] = useState<PerformanceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchPerformance(year, accountId)
+      .then((res) => {
+        if (!cancelled) setPerformance(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '성과 데이터를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [year, accountId, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { performance, loading, error, refetch };
+}
+
+// ─── useTrades ────────────────────────────────────────────────────────────────
+
+interface UseTradesReturn {
+  data: PaginatedResponse<Trade> | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  create: (dto: CreateTradeDto) => Promise<void>;
+  update: (id: string, dto: UpdateTradeDto) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export function useTrades(filters: TradeFilters = {}): UseTradesReturn {
+  const [data, setData] = useState<PaginatedResponse<Trade> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  const filtersKey = JSON.stringify(filters);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchTrades(filters)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '매매 내역을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtersKey, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  const create = useCallback(
+    async (dto: CreateTradeDto) => {
+      await createTrade(dto);
+      refetch();
+    },
+    [refetch],
+  );
+
+  const update = useCallback(
+    async (id: string, dto: UpdateTradeDto) => {
+      await updateTrade(id, dto);
+      refetch();
+    },
+    [refetch],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await deleteTrade(id);
+      refetch();
+    },
+    [refetch],
+  );
+
+  return { data, loading, error, refetch, create, update, remove };
+}
+
+// ─── useStocks ────────────────────────────────────────────────────────────────
+
+interface UseStocksReturn {
+  stocks: Stock[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useStocks(search?: string): UseStocksReturn {
+  const [stocks, setStocks] = useState<Stock[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchStocks(search)
+      .then((res) => {
+        if (!cancelled) setStocks(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '종목 목록을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [search, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { stocks, loading, error, refetch };
+}
+
+// ─── useStockAccounts ─────────────────────────────────────────────────────────
+
+interface UseStockAccountsReturn {
+  accounts: StockAccount[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  create: (dto: CreateStockAccountDto) => Promise<void>;
+}
+
+export function useStockAccounts(): UseStockAccountsReturn {
+  const [accounts, setAccounts] = useState<StockAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchStockAccounts()
+      .then((res) => {
+        if (!cancelled) setAccounts(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '계좌 목록을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  const create = useCallback(
+    async (dto: CreateStockAccountDto) => {
+      await createStockAccount(dto);
+      refetch();
+    },
+    [refetch],
+  );
+
+  return { accounts, loading, error, refetch, create };
+}
+
+// ─── useStockDetail ───────────────────────────────────────────────────────────
+
+interface UseStockDetailReturn {
+  stock: Stock | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useStockDetail(stockId: string): UseStockDetailReturn {
+  const [stock, setStock] = useState<Stock | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchStock(stockId)
+      .then((res) => {
+        if (!cancelled) setStock(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '종목 정보를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [stockId]);
+
+  return { stock, loading, error };
+}
+
+// ─── useTradeRealizedGains ────────────────────────────────────────────────────
+
+interface UseTradeRealizedGainsReturn {
+  gains: RealizedGain[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useTradeRealizedGains(tradeId: string): UseTradeRealizedGainsReturn {
+  const [gains, setGains] = useState<RealizedGain[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchTradeRealizedGains(tradeId)
+      .then((res) => {
+        if (!cancelled) setGains(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '실현 손익을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [tradeId]);
+
+  return { gains, loading, error };
+}

--- a/apps/web/lib/api/stock.ts
+++ b/apps/web/lib/api/stock.ts
@@ -1,0 +1,188 @@
+import { apiClient } from '@/lib/api-client';
+import type {
+  TradeType,
+  AccountType,
+  HoldingItem,
+  PortfolioSummary,
+  PerformanceItem,
+} from '@my-wallet/shared';
+import type { PaginatedResponse } from '@my-wallet/shared';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface Stock {
+  id: string;
+  code: string;
+  name: string;
+  market?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StockPrice {
+  stockId: string;
+  price: number;
+  updatedAt: string;
+}
+
+export interface StockAccount {
+  id: string;
+  type: AccountType;
+  broker: string;
+  alias?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Trade {
+  id: string;
+  stockId: string;
+  stock?: Stock;
+  accountId: string;
+  account?: StockAccount;
+  type: TradeType;
+  tradeDate: string;
+  price: number;
+  quantity: number;
+  totalAmount: number;
+  reason?: string[];
+  memo?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RealizedGain {
+  tradeId: string;
+  stockId: string;
+  stockName: string;
+  stockCode: string;
+  buyPrice: number;
+  sellPrice: number;
+  quantity: number;
+  gain: number;
+  gainRate: number;
+  tradeDate: string;
+}
+
+export interface TradeFilters {
+  stockId?: string;
+  accountId?: string;
+  type?: TradeType;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface CreateTradeDto {
+  stockId: string;
+  accountId: string;
+  type: TradeType;
+  tradeDate: string;
+  price: number;
+  quantity: number;
+  reason?: string[];
+  memo?: string;
+}
+
+export interface UpdateTradeDto {
+  tradeDate?: string;
+  price?: number;
+  quantity?: number;
+  reason?: string[];
+  memo?: string;
+}
+
+export interface CreateStockDto {
+  code: string;
+  name: string;
+  market?: string;
+}
+
+export interface CreateStockAccountDto {
+  type: AccountType;
+  broker: string;
+  alias?: string;
+}
+
+// ─── Trade API ────────────────────────────────────────────────────────────────
+
+export function fetchTrades(filters: TradeFilters = {}): Promise<PaginatedResponse<Trade>> {
+  const params = new URLSearchParams();
+  if (filters.stockId) params.set('stockId', filters.stockId);
+  if (filters.accountId) params.set('accountId', filters.accountId);
+  if (filters.type) params.set('type', filters.type);
+  if (filters.startDate) params.set('startDate', filters.startDate);
+  if (filters.endDate) params.set('endDate', filters.endDate);
+  if (filters.page !== undefined) params.set('page', String(filters.page));
+  if (filters.limit !== undefined) params.set('limit', String(filters.limit));
+  const query = params.toString();
+  return apiClient.get<PaginatedResponse<Trade>>(`/trades${query ? `?${query}` : ''}`);
+}
+
+export function fetchTrade(id: string): Promise<Trade> {
+  return apiClient.get<Trade>(`/trades/${id}`);
+}
+
+export function fetchTradeRealizedGains(id: string): Promise<RealizedGain[]> {
+  return apiClient.get<RealizedGain[]>(`/trades/${id}/realized-gains`);
+}
+
+export function createTrade(dto: CreateTradeDto): Promise<Trade> {
+  return apiClient.post<Trade>('/trades', dto);
+}
+
+export function updateTrade(id: string, dto: UpdateTradeDto): Promise<Trade> {
+  return apiClient.put<Trade>(`/trades/${id}`, dto);
+}
+
+export function deleteTrade(id: string): Promise<void> {
+  return apiClient.delete<void>(`/trades/${id}`);
+}
+
+// ─── Portfolio API ────────────────────────────────────────────────────────────
+
+export function fetchPortfolioSummary(accountId?: string): Promise<PortfolioSummary> {
+  const query = accountId ? `?accountId=${accountId}` : '';
+  return apiClient.get<PortfolioSummary>(`/portfolio/summary${query}`);
+}
+
+export function fetchHoldings(accountId?: string): Promise<HoldingItem[]> {
+  const query = accountId ? `?accountId=${accountId}` : '';
+  return apiClient.get<HoldingItem[]>(`/portfolio/holdings${query}`);
+}
+
+export function fetchPerformance(year: number, accountId?: string): Promise<PerformanceItem[]> {
+  const params = new URLSearchParams({ year: String(year) });
+  if (accountId) params.set('accountId', accountId);
+  return apiClient.get<PerformanceItem[]>(`/portfolio/performance?${params.toString()}`);
+}
+
+// ─── Stock API ────────────────────────────────────────────────────────────────
+
+export function fetchStocks(search?: string): Promise<Stock[]> {
+  const query = search ? `?search=${encodeURIComponent(search)}` : '';
+  return apiClient.get<Stock[]>(`/stocks${query}`);
+}
+
+export function fetchStock(id: string): Promise<Stock> {
+  return apiClient.get<Stock>(`/stocks/${id}`);
+}
+
+export function fetchStockPrice(id: string): Promise<StockPrice> {
+  return apiClient.get<StockPrice>(`/stocks/${id}/price`);
+}
+
+export function createStock(dto: CreateStockDto): Promise<Stock> {
+  return apiClient.post<Stock>('/stocks', dto);
+}
+
+// ─── Stock Account API ────────────────────────────────────────────────────────
+
+export function fetchStockAccounts(): Promise<StockAccount[]> {
+  return apiClient.get<StockAccount[]>('/stock-accounts');
+}
+
+export function createStockAccount(dto: CreateStockAccountDto): Promise<StockAccount> {
+  return apiClient.post<StockAccount>('/stock-accounts', dto);
+}


### PR DESCRIPTION
## Summary
- Backend 단위 테스트 96개 추가 (Trade, FIFO, Portfolio, Stock, StockPrice, Controllers)
- 주식 포트폴리오 프론트엔드 전체 구현 (매매 CRUD, 보유종목, 종목상세, 계좌상세)
- 전체 테스트 171개 통과, 빌드 정상

## Changes

### Backend (apps/api) — 9 spec files, 96 tests
- `trade.service.spec.ts` — 34 tests (CRUD, 매도 보유량 검증, FIFO 연동)
- `fifo.service.spec.ts` — 29 tests (FIFO 매칭: 단일/다건/기사용량, 손익계산, 에러)
- `portfolio.service.spec.ts` — 10 tests (보유종목 집계, 요약, 월별 성과)
- `stock.service.spec.ts` — 10 tests (종목/계좌 CRUD)
- `stock-price.service.spec.ts` — 9 tests (캐시, 대량업데이트)
- Controllers — 4 files (라우트 위임, Guard 검증)

### Frontend (apps/web) — 11 files
- `lib/api/stock.ts` — 타입드 API 함수
- `hooks/use-stock.ts` — 8개 커스텀 훅
- `components/stock/` — 5개 컴포넌트 (holdings-table, trade-form/table, performance-chart, account-form)
- 4개 페이지 구현 (포트폴리오, 매매내역, 종목상세, 계좌상세)

## Related Issues
Closes #8, Closes #9, Closes #10

## Test Plan
- [x] `npx jest` — 171/171 tests pass (75 budget + 96 stock)
- [x] `turbo build` — 4/4 tasks successful
- [ ] Manual: 계좌 등록 → 종목 등록 → 매수 → 매도(FIFO) → 포트폴리오 확인
- [ ] Manual: 종목상세, 계좌상세 페이지 확인