### PR TITLE
feat(m3): Dashboard & Notion Migration

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { BudgetModule } from './budget/budget.module';
 import { StockModule } from './stock/stock.module';
+import { MigrationModule } from './migration/migration.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { StockModule } from './stock/stock.module';
     AuthModule,
     BudgetModule,
     StockModule,
+    MigrationModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/migration/dto/import-budgets.dto.ts
+++ b/apps/api/src/migration/dto/import-budgets.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  Min,
+  IsEnum,
+  IsDateString,
+  IsArray,
+  ValidateNested,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ImportBudgetItem {
+  @ApiProperty({ description: '카테고리 이름', example: '식비' })
+  @IsString()
+  @IsNotEmpty({ message: '카테고리 이름은 필수 입력입니다.' })
+  categoryName: string;
+
+  @ApiProperty({ description: '거래 유형', enum: ['INCOME', 'EXPENSE', 'SAVING'] })
+  @IsEnum(['INCOME', 'EXPENSE', 'SAVING'] as const, {
+    message: '유형은 INCOME, EXPENSE, SAVING 중 하나여야 합니다.',
+  })
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+
+  @ApiProperty({ description: '예산 월 (YYYY-MM-DD, 월의 첫 날)', example: '2026-03-01' })
+  @IsDateString({}, { message: '유효한 날짜 형식이어야 합니다.' })
+  month: string;
+
+  @ApiProperty({ description: '예산 금액 (원)', example: 300000, minimum: 1 })
+  @IsInt({ message: '금액은 정수여야 합니다.' })
+  @Min(1, { message: '금액은 1원 이상이어야 합니다.' })
+  amount: number;
+}
+
+export class ImportBudgetsDto {
+  @ApiProperty({ type: [ImportBudgetItem], description: '예산 목록' })
+  @IsArray()
+  @ArrayNotEmpty({ message: '예산 목록이 비어있습니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => ImportBudgetItem)
+  items: ImportBudgetItem[];
+}

--- a/apps/api/src/migration/dto/import-trades.dto.ts
+++ b/apps/api/src/migration/dto/import-trades.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  Min,
+  IsEnum,
+  IsDateString,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ImportTradeItem {
+  @ApiProperty({ description: '종목 코드', example: '005930' })
+  @IsString()
+  @IsNotEmpty({ message: '종목 코드는 필수 입력입니다.' })
+  stockCode: string;
+
+  @ApiProperty({ description: '증권사', example: '키움증권' })
+  @IsString()
+  @IsNotEmpty({ message: '증권사는 필수 입력입니다.' })
+  accountBroker: string;
+
+  @ApiProperty({ description: '계좌 유형', enum: ['GENERAL', 'ISA', 'PENSION', 'IRP'] })
+  @IsEnum(['GENERAL', 'ISA', 'PENSION', 'IRP'] as const, {
+    message: '계좌 유형은 GENERAL, ISA, PENSION, IRP 중 하나여야 합니다.',
+  })
+  accountType: 'GENERAL' | 'ISA' | 'PENSION' | 'IRP';
+
+  @ApiProperty({ description: '매매 유형', enum: ['BUY', 'SELL'] })
+  @IsEnum(['BUY', 'SELL'] as const, {
+    message: '유형은 BUY 또는 SELL이어야 합니다.',
+  })
+  type: 'BUY' | 'SELL';
+
+  @ApiProperty({ description: '거래 날짜 (YYYY-MM-DD)', example: '2026-03-15' })
+  @IsDateString({}, { message: '유효한 날짜 형식이어야 합니다.' })
+  tradeDate: string;
+
+  @ApiProperty({ description: '매매 단가 (원)', example: 70000, minimum: 1 })
+  @IsInt({ message: '단가는 정수여야 합니다.' })
+  @Min(1, { message: '단가는 1원 이상이어야 합니다.' })
+  price: number;
+
+  @ApiProperty({ description: '수량', example: 10, minimum: 1 })
+  @IsInt({ message: '수량은 정수여야 합니다.' })
+  @Min(1, { message: '수량은 1 이상이어야 합니다.' })
+  quantity: number;
+
+  @ApiPropertyOptional({
+    description: '매매 사유',
+    type: [String],
+    example: ['실적 호조', '저평가'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  reason?: string[];
+
+  @ApiPropertyOptional({ description: '메모' })
+  @IsOptional()
+  @IsString()
+  memo?: string;
+}
+
+export class ImportTradesDto {
+  @ApiProperty({ type: [ImportTradeItem], description: '거래 목록' })
+  @IsArray()
+  @ArrayNotEmpty({ message: '거래 목록이 비어있습니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => ImportTradeItem)
+  items: ImportTradeItem[];
+}

--- a/apps/api/src/migration/dto/import-transactions.dto.ts
+++ b/apps/api/src/migration/dto/import-transactions.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  Min,
+  IsEnum,
+  IsBoolean,
+  IsOptional,
+  IsDateString,
+  IsArray,
+  ValidateNested,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ImportTransactionItem {
+  @ApiProperty({ description: '카테고리 이름', example: '식비' })
+  @IsString()
+  @IsNotEmpty({ message: '카테고리 이름은 필수 입력입니다.' })
+  categoryName: string;
+
+  @ApiProperty({ description: '거래 유형', enum: ['INCOME', 'EXPENSE', 'SAVING'] })
+  @IsEnum(['INCOME', 'EXPENSE', 'SAVING'] as const, {
+    message: '유형은 INCOME, EXPENSE, SAVING 중 하나여야 합니다.',
+  })
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+
+  @ApiProperty({ description: '거래 제목', example: '점심식사' })
+  @IsString()
+  @IsNotEmpty({ message: '제목은 필수 입력입니다.' })
+  title: string;
+
+  @ApiProperty({ description: '금액 (원)', example: 12000, minimum: 1 })
+  @IsInt({ message: '금액은 정수여야 합니다.' })
+  @Min(1, { message: '금액은 1원 이상이어야 합니다.' })
+  amount: number;
+
+  @ApiProperty({ description: '거래 날짜 (YYYY-MM-DD)', example: '2026-03-15' })
+  @IsDateString({}, { message: '유효한 날짜 형식이어야 합니다.' })
+  date: string;
+
+  @ApiPropertyOptional({ description: '고정 지출 여부', default: false })
+  @IsOptional()
+  @IsBoolean()
+  isFixed?: boolean;
+
+  @ApiPropertyOptional({ description: '메모' })
+  @IsOptional()
+  @IsString()
+  memo?: string;
+}
+
+export class ImportTransactionsDto {
+  @ApiProperty({ type: [ImportTransactionItem], description: '거래 내역 목록' })
+  @IsArray()
+  @ArrayNotEmpty({ message: '거래 내역 목록이 비어있습니다.' })
+  @ValidateNested({ each: true })
+  @Type(() => ImportTransactionItem)
+  items: ImportTransactionItem[];
+}

--- a/apps/api/src/migration/migration.controller.spec.ts
+++ b/apps/api/src/migration/migration.controller.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MigrationController } from './migration.controller';
+import { MigrationService } from './migration.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+
+const USER_ID = 'user-001';
+const mockReq = { user: { id: USER_ID } };
+
+const mockMigrationService = {
+  importTransactions: jest.fn(),
+  importBudgets: jest.fn(),
+  importTrades: jest.fn(),
+};
+
+describe('MigrationController', () => {
+  let controller: MigrationController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MigrationController],
+      providers: [
+        { provide: MigrationService, useValue: mockMigrationService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<MigrationController>(MigrationController);
+  });
+
+  describe('POST /migration/notion/transactions', () => {
+    it('importTransactions 서비스를 호출하고 결과를 반환한다', async () => {
+      const dto = {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE' as const,
+            title: '점심식사',
+            amount: 12000,
+            date: '2026-03-15',
+          },
+        ],
+      };
+
+      const mockResult = { imported: 1, skipped: 0, errors: [] };
+      mockMigrationService.importTransactions.mockResolvedValue(mockResult);
+
+      const result = await controller.importTransactions(mockReq, dto);
+
+      expect(mockMigrationService.importTransactions).toHaveBeenCalledWith(USER_ID, dto);
+      expect(result).toEqual(mockResult);
+    });
+
+    it('일부 항목이 건너뛰어진 결과를 반환한다', async () => {
+      const dto = {
+        items: [
+          {
+            categoryName: '없는카테고리',
+            type: 'EXPENSE' as const,
+            title: '테스트',
+            amount: 1000,
+            date: '2026-03-15',
+          },
+        ],
+      };
+
+      const mockResult = {
+        imported: 0,
+        skipped: 1,
+        errors: ['카테고리를 찾을 수 없습니다: name="없는카테고리", type="EXPENSE"'],
+      };
+      mockMigrationService.importTransactions.mockResolvedValue(mockResult);
+
+      const result = await controller.importTransactions(mockReq, dto);
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('POST /migration/notion/budgets', () => {
+    it('importBudgets 서비스를 호출하고 결과를 반환한다', async () => {
+      const dto = {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE' as const,
+            month: '2026-03-01',
+            amount: 300000,
+          },
+        ],
+      };
+
+      const mockResult = { imported: 1, skipped: 0, errors: [] };
+      mockMigrationService.importBudgets.mockResolvedValue(mockResult);
+
+      const result = await controller.importBudgets(mockReq, dto);
+
+      expect(mockMigrationService.importBudgets).toHaveBeenCalledWith(USER_ID, dto);
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('POST /migration/notion/trades', () => {
+    it('importTrades 서비스를 호출하고 결과를 반환한다', async () => {
+      const dto = {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL' as const,
+            type: 'BUY' as const,
+            tradeDate: '2026-01-10',
+            price: 70000,
+            quantity: 10,
+          },
+        ],
+      };
+
+      const mockResult = {
+        imported: 1,
+        skipped: 0,
+        errors: [],
+        totalBuyAmount: 700000,
+        totalSellAmount: 0,
+      };
+      mockMigrationService.importTrades.mockResolvedValue(mockResult);
+
+      const result = await controller.importTrades(mockReq, dto);
+
+      expect(mockMigrationService.importTrades).toHaveBeenCalledWith(USER_ID, dto);
+      expect(result).toEqual(mockResult);
+    });
+
+    it('SELL 거래의 총 매도 금액을 포함한 결과를 반환한다', async () => {
+      const dto = {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL' as const,
+            type: 'SELL' as const,
+            tradeDate: '2026-02-10',
+            price: 80000,
+            quantity: 5,
+          },
+        ],
+      };
+
+      const mockResult = {
+        imported: 1,
+        skipped: 0,
+        errors: [],
+        totalBuyAmount: 0,
+        totalSellAmount: 400000,
+      };
+      mockMigrationService.importTrades.mockResolvedValue(mockResult);
+
+      const result = await controller.importTrades(mockReq, dto);
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+});

--- a/apps/api/src/migration/migration.controller.ts
+++ b/apps/api/src/migration/migration.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { MigrationService } from './migration.service';
+import { ImportTransactionsDto } from './dto/import-transactions.dto';
+import { ImportBudgetsDto } from './dto/import-budgets.dto';
+import { ImportTradesDto } from './dto/import-trades.dto';
+
+@ApiTags('Migration')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('migration/notion')
+export class MigrationController {
+  constructor(private readonly migrationService: MigrationService) {}
+
+  @Post('transactions')
+  @ApiOperation({ summary: 'Notion 거래 내역 일괄 가져오기' })
+  importTransactions(
+    @Request() req: { user: { id: string } },
+    @Body() dto: ImportTransactionsDto,
+  ) {
+    return this.migrationService.importTransactions(req.user.id, dto);
+  }
+
+  @Post('budgets')
+  @ApiOperation({ summary: 'Notion 예산 일괄 가져오기' })
+  importBudgets(
+    @Request() req: { user: { id: string } },
+    @Body() dto: ImportBudgetsDto,
+  ) {
+    return this.migrationService.importBudgets(req.user.id, dto);
+  }
+
+  @Post('trades')
+  @ApiOperation({ summary: 'Notion 주식 거래 일괄 가져오기' })
+  importTrades(
+    @Request() req: { user: { id: string } },
+    @Body() dto: ImportTradesDto,
+  ) {
+    return this.migrationService.importTrades(req.user.id, dto);
+  }
+}

--- a/apps/api/src/migration/migration.module.ts
+++ b/apps/api/src/migration/migration.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MigrationController } from './migration.controller';
+import { MigrationService } from './migration.service';
+import { StockModule } from '../stock/stock.module';
+
+@Module({
+  imports: [StockModule],
+  controllers: [MigrationController],
+  providers: [MigrationService],
+})
+export class MigrationModule {}

--- a/apps/api/src/migration/migration.service.spec.ts
+++ b/apps/api/src/migration/migration.service.spec.ts
@@ -1,0 +1,491 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MigrationService } from './migration.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { FifoService } from '../stock/services/fifo.service';
+import { BadRequestException } from '@nestjs/common';
+
+const USER_ID = 'user-001';
+const CAT_ID = 'cat-001';
+const STOCK_ID = 'stock-001';
+const ACCOUNT_ID = 'account-001';
+const TRADE_ID = 'trade-001';
+
+const mockCategory = {
+  id: CAT_ID,
+  name: '식비',
+  type: 'EXPENSE',
+  sortOrder: 1,
+  isActive: true,
+};
+
+const mockStock = {
+  id: STOCK_ID,
+  code: '005930',
+  name: '삼성전자',
+  market: 'KRX',
+  isActive: true,
+};
+
+const mockAccount = {
+  id: ACCOUNT_ID,
+  userId: USER_ID,
+  type: 'GENERAL',
+  broker: '키움증권',
+  alias: null,
+  isActive: true,
+};
+
+const mockTrade = {
+  id: TRADE_ID,
+  userId: USER_ID,
+  stockId: STOCK_ID,
+  accountId: ACCOUNT_ID,
+  type: 'BUY',
+  tradeDate: new Date('2026-01-10'),
+  price: 70000,
+  quantity: 10,
+  reason: [],
+  memo: null,
+};
+
+const mockPrisma = {
+  category: {
+    findFirst: jest.fn(),
+  },
+  transaction: {
+    createMany: jest.fn(),
+  },
+  budget: {
+    upsert: jest.fn(),
+  },
+  stock: {
+    findUnique: jest.fn(),
+  },
+  stockAccount: {
+    findFirst: jest.fn(),
+  },
+  trade: {
+    create: jest.fn(),
+  },
+};
+
+const mockFifoService = {
+  calculateRealizedGain: jest.fn(),
+};
+
+describe('MigrationService', () => {
+  let service: MigrationService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MigrationService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: FifoService, useValue: mockFifoService },
+      ],
+    }).compile();
+
+    service = module.get<MigrationService>(MigrationService);
+  });
+
+  describe('importTransactions - 거래 내역 일괄 가져오기', () => {
+    it('유효한 카테고리로 거래를 일괄 생성한다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(mockCategory);
+      mockPrisma.transaction.createMany.mockResolvedValue({ count: 2 });
+
+      const result = await service.importTransactions(USER_ID, {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            title: '점심식사',
+            amount: 12000,
+            date: '2026-03-15',
+          },
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            title: '저녁식사',
+            amount: 15000,
+            date: '2026-03-16',
+            isFixed: false,
+            memo: '맛집',
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(mockPrisma.transaction.createMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('카테고리를 찾을 수 없으면 해당 항목을 건너뛴다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+
+      const result = await service.importTransactions(USER_ID, {
+        items: [
+          {
+            categoryName: '없는카테고리',
+            type: 'EXPENSE',
+            title: '테스트',
+            amount: 1000,
+            date: '2026-03-15',
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('없는카테고리');
+      expect(mockPrisma.transaction.createMany).not.toHaveBeenCalled();
+    });
+
+    it('카테고리를 찾을 수 없는 항목은 건너뛰고 나머지는 가져온다', async () => {
+      mockPrisma.category.findFirst
+        .mockResolvedValueOnce(mockCategory)
+        .mockResolvedValueOnce(null);
+      mockPrisma.transaction.createMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.importTransactions(USER_ID, {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            title: '점심',
+            amount: 12000,
+            date: '2026-03-15',
+          },
+          {
+            categoryName: '없는카테고리',
+            type: 'EXPENSE',
+            title: '저녁',
+            amount: 15000,
+            date: '2026-03-16',
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('빈 목록은 처리하지 않는다', async () => {
+      mockPrisma.transaction.createMany.mockResolvedValue({ count: 0 });
+
+      // DTO validation prevents empty array, but service handles it gracefully
+      const result = await service.importTransactions(USER_ID, {
+        items: [],
+      });
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(mockPrisma.transaction.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('importBudgets - 예산 일괄 가져오기', () => {
+    it('유효한 카테고리로 예산을 일괄 생성한다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(mockCategory);
+      mockPrisma.budget.upsert.mockResolvedValue({ id: 'budget-001' });
+
+      const result = await service.importBudgets(USER_ID, {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            month: '2026-03-01',
+            amount: 300000,
+          },
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            month: '2026-04-01',
+            amount: 320000,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(mockPrisma.budget.upsert).toHaveBeenCalledTimes(2);
+    });
+
+    it('동일한 userId+categoryId+month 조합은 upsert로 업데이트한다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(mockCategory);
+      mockPrisma.budget.upsert.mockResolvedValue({ id: 'budget-001', amount: 350000 });
+
+      const result = await service.importBudgets(USER_ID, {
+        items: [
+          {
+            categoryName: '식비',
+            type: 'EXPENSE',
+            month: '2026-03-01',
+            amount: 350000,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(mockPrisma.budget.upsert).toHaveBeenCalledWith({
+        where: {
+          userId_categoryId_month: {
+            userId: USER_ID,
+            categoryId: CAT_ID,
+            month: new Date('2026-03-01'),
+          },
+        },
+        update: { amount: 350000, type: 'EXPENSE' },
+        create: {
+          userId: USER_ID,
+          categoryId: CAT_ID,
+          type: 'EXPENSE',
+          month: new Date('2026-03-01'),
+          amount: 350000,
+        },
+      });
+    });
+
+    it('카테고리를 찾을 수 없으면 건너뛴다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+
+      const result = await service.importBudgets(USER_ID, {
+        items: [
+          {
+            categoryName: '없는카테고리',
+            type: 'EXPENSE',
+            month: '2026-03-01',
+            amount: 300000,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('없는카테고리');
+      expect(mockPrisma.budget.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('importTrades - 주식 거래 일괄 가져오기', () => {
+    it('BUY 거래를 정상적으로 가져온다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+      mockPrisma.trade.create.mockResolvedValue({ ...mockTrade, type: 'BUY' });
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-01-10',
+            price: 70000,
+            quantity: 10,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(result.totalBuyAmount).toBe(700000);
+      expect(result.totalSellAmount).toBe(0);
+      expect(mockFifoService.calculateRealizedGain).not.toHaveBeenCalled();
+    });
+
+    it('SELL 거래에 대해 FIFO 계산을 호출한다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+      mockPrisma.trade.create.mockResolvedValue({ ...mockTrade, id: 'sell-001', type: 'SELL', price: 80000 });
+      mockFifoService.calculateRealizedGain.mockResolvedValue(undefined);
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'SELL',
+            tradeDate: '2026-02-10',
+            price: 80000,
+            quantity: 5,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(1);
+      expect(result.totalSellAmount).toBe(400000);
+      expect(mockFifoService.calculateRealizedGain).toHaveBeenCalledWith('sell-001');
+    });
+
+    it('FIFO 계산 오류가 발생해도 거래는 가져온다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+      mockPrisma.trade.create.mockResolvedValue({ ...mockTrade, id: 'sell-001', type: 'SELL', price: 80000 });
+      mockFifoService.calculateRealizedGain.mockRejectedValue(
+        new BadRequestException('FIFO 매칭 실패'),
+      );
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'SELL',
+            tradeDate: '2026-02-10',
+            price: 80000,
+            quantity: 5,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('FIFO 계산 오류');
+    });
+
+    it('종목을 찾을 수 없으면 건너뛴다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(null);
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '999999',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-01-10',
+            price: 10000,
+            quantity: 10,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('999999');
+      expect(mockPrisma.trade.create).not.toHaveBeenCalled();
+    });
+
+    it('계좌를 찾을 수 없으면 건너뛴다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(null);
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '없는증권사',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-01-10',
+            price: 70000,
+            quantity: 10,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('없는증권사');
+      expect(mockPrisma.trade.create).not.toHaveBeenCalled();
+    });
+
+    it('거래를 tradeDate ASC 순으로 정렬하여 처리한다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+
+      const tradeCalls: string[] = [];
+      mockPrisma.trade.create.mockImplementation((args: { data: { tradeDate: Date; type: string } }) => {
+        tradeCalls.push(args.data.tradeDate.toISOString().split('T')[0]);
+        return Promise.resolve({ ...mockTrade, type: args.data.type });
+      });
+
+      await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-03-01',
+            price: 70000,
+            quantity: 5,
+          },
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-01-15',
+            price: 65000,
+            quantity: 10,
+          },
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-02-10',
+            price: 68000,
+            quantity: 7,
+          },
+        ],
+      });
+
+      expect(tradeCalls[0]).toBe('2026-01-15');
+      expect(tradeCalls[1]).toBe('2026-02-10');
+      expect(tradeCalls[2]).toBe('2026-03-01');
+    });
+
+    it('BUY와 SELL 거래의 금액을 합산한다', async () => {
+      mockPrisma.stock.findUnique.mockResolvedValue(mockStock);
+      mockPrisma.stockAccount.findFirst.mockResolvedValue(mockAccount);
+      mockFifoService.calculateRealizedGain.mockResolvedValue(undefined);
+
+      mockPrisma.trade.create
+        .mockResolvedValueOnce({ ...mockTrade, type: 'BUY', price: 70000, quantity: 10 })
+        .mockResolvedValueOnce({ ...mockTrade, id: 'sell-001', type: 'SELL', price: 80000, quantity: 5 });
+
+      const result = await service.importTrades(USER_ID, {
+        items: [
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'BUY',
+            tradeDate: '2026-01-10',
+            price: 70000,
+            quantity: 10,
+          },
+          {
+            stockCode: '005930',
+            accountBroker: '키움증권',
+            accountType: 'GENERAL',
+            type: 'SELL',
+            tradeDate: '2026-02-10',
+            price: 80000,
+            quantity: 5,
+          },
+        ],
+      });
+
+      expect(result.imported).toBe(2);
+      expect(result.totalBuyAmount).toBe(700000);
+      expect(result.totalSellAmount).toBe(400000);
+    });
+  });
+});

--- a/apps/api/src/migration/migration.service.ts
+++ b/apps/api/src/migration/migration.service.ts
@@ -1,0 +1,223 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { FifoService } from '../stock/services/fifo.service';
+import { ImportTransactionsDto } from './dto/import-transactions.dto';
+import { ImportBudgetsDto } from './dto/import-budgets.dto';
+import { ImportTradesDto } from './dto/import-trades.dto';
+
+export interface MigrationResult {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}
+
+export interface TradesMigrationResult extends MigrationResult {
+  totalBuyAmount: number;
+  totalSellAmount: number;
+}
+
+@Injectable()
+export class MigrationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly fifoService: FifoService,
+  ) {}
+
+  async importTransactions(
+    userId: string,
+    dto: ImportTransactionsDto,
+  ): Promise<MigrationResult> {
+    let imported = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+
+    const createDataList: {
+      userId: string;
+      categoryId: string;
+      type: 'INCOME' | 'EXPENSE' | 'SAVING';
+      title: string;
+      amount: number;
+      date: Date;
+      isFixed: boolean;
+      memo?: string | null;
+    }[] = [];
+
+    for (const item of dto.items) {
+      try {
+        const category = await this.prisma.category.findFirst({
+          where: { name: item.categoryName, type: item.type },
+        });
+
+        if (!category) {
+          skipped++;
+          errors.push(
+            `카테고리를 찾을 수 없습니다: name="${item.categoryName}", type="${item.type}"`,
+          );
+          continue;
+        }
+
+        createDataList.push({
+          userId,
+          categoryId: category.id,
+          type: item.type,
+          title: item.title,
+          amount: item.amount,
+          date: new Date(item.date),
+          isFixed: item.isFixed ?? false,
+          memo: item.memo ?? null,
+        });
+      } catch (err) {
+        skipped++;
+        errors.push(
+          `거래 처리 중 오류: title="${item.title}", error=${(err as Error).message}`,
+        );
+      }
+    }
+
+    if (createDataList.length > 0) {
+      const result = await this.prisma.transaction.createMany({
+        data: createDataList,
+      });
+      imported = result.count;
+    }
+
+    return { imported, skipped, errors };
+  }
+
+  async importBudgets(
+    userId: string,
+    dto: ImportBudgetsDto,
+  ): Promise<MigrationResult> {
+    let imported = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+
+    for (const item of dto.items) {
+      try {
+        const category = await this.prisma.category.findFirst({
+          where: { name: item.categoryName, type: item.type },
+        });
+
+        if (!category) {
+          skipped++;
+          errors.push(
+            `카테고리를 찾을 수 없습니다: name="${item.categoryName}", type="${item.type}"`,
+          );
+          continue;
+        }
+
+        await this.prisma.budget.upsert({
+          where: {
+            userId_categoryId_month: {
+              userId,
+              categoryId: category.id,
+              month: new Date(item.month),
+            },
+          },
+          update: {
+            amount: item.amount,
+            type: item.type,
+          },
+          create: {
+            userId,
+            categoryId: category.id,
+            type: item.type,
+            month: new Date(item.month),
+            amount: item.amount,
+          },
+        });
+
+        imported++;
+      } catch (err) {
+        skipped++;
+        errors.push(
+          `예산 처리 중 오류: category="${item.categoryName}", month="${item.month}", error=${(err as Error).message}`,
+        );
+      }
+    }
+
+    return { imported, skipped, errors };
+  }
+
+  async importTrades(
+    userId: string,
+    dto: ImportTradesDto,
+  ): Promise<TradesMigrationResult> {
+    let imported = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+    let totalBuyAmount = 0;
+    let totalSellAmount = 0;
+
+    // Sort by tradeDate ASC for correct FIFO processing
+    const sortedItems = [...dto.items].sort(
+      (a, b) => new Date(a.tradeDate).getTime() - new Date(b.tradeDate).getTime(),
+    );
+
+    for (const item of sortedItems) {
+      try {
+        const stock = await this.prisma.stock.findUnique({
+          where: { code: item.stockCode },
+        });
+
+        if (!stock) {
+          skipped++;
+          errors.push(`종목을 찾을 수 없습니다: code="${item.stockCode}"`);
+          continue;
+        }
+
+        const account = await this.prisma.stockAccount.findFirst({
+          where: {
+            userId,
+            broker: item.accountBroker,
+            type: item.accountType,
+          },
+        });
+
+        if (!account) {
+          skipped++;
+          errors.push(
+            `계좌를 찾을 수 없습니다: broker="${item.accountBroker}", type="${item.accountType}"`,
+          );
+          continue;
+        }
+
+        const trade = await this.prisma.trade.create({
+          data: {
+            userId,
+            stockId: stock.id,
+            accountId: account.id,
+            type: item.type,
+            tradeDate: new Date(item.tradeDate),
+            price: item.price,
+            quantity: item.quantity,
+            reason: item.reason ?? [],
+            memo: item.memo ?? null,
+          },
+        });
+
+        if (item.type === 'BUY') {
+          totalBuyAmount += item.price * item.quantity;
+        } else if (item.type === 'SELL') {
+          totalSellAmount += item.price * item.quantity;
+          try {
+            await this.fifoService.calculateRealizedGain(trade.id);
+          } catch (fifoErr) {
+            errors.push(
+              `FIFO 계산 오류: tradeDate="${item.tradeDate}", stock="${item.stockCode}", error=${(fifoErr as Error).message}`,
+            );
+          }
+        }
+
+        imported++;
+      } catch (err) {
+        skipped++;
+        errors.push(
+          `거래 처리 중 오류: stock="${item.stockCode}", date="${item.tradeDate}", error=${(err as Error).message}`,
+        );
+      }
+    }
+
+    return { imported, skipped, errors, totalBuyAmount, totalSellAmount };
+  }
+}

--- a/apps/web/app/(main)/dashboard/page.tsx
+++ b/apps/web/app/(main)/dashboard/page.tsx
@@ -1,57 +1,171 @@
+'use client';
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { LayoutDashboard } from 'lucide-react';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { BudgetSummary } from '@/components/dashboard/budget-summary';
+import { HoldingsSummary } from '@/components/dashboard/holdings-summary';
+import { RecentActivity } from '@/components/dashboard/recent-activity';
+import { useMonthlySummary, useBudgetAnalysis } from '@/hooks/use-budget';
+import { usePortfolioSummary, useHoldings } from '@/hooks/use-stock';
+import { useRecentActivity } from '@/hooks/use-dashboard';
+import { formatPercent, formatMonth } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { TrendingUp, TrendingDown, Wallet, PiggyBank } from 'lucide-react';
+
+// ─── Summary Card ─────────────────────────────────────────────────────────────
+
+interface SummaryCardProps {
+  title: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  icon: React.ReactNode;
+  loading: boolean;
+}
+
+function SummaryCard({ title, value, sub, icon, loading }: SummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <span className="text-muted-foreground">{icon}</span>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="space-y-2 animate-pulse">
+            <div className="h-7 w-32 rounded bg-muted" />
+            {sub !== undefined && <div className="h-4 w-20 rounded bg-muted" />}
+          </div>
+        ) : (
+          <>
+            <div className="text-2xl font-bold">{value}</div>
+            {sub && <div className="mt-1 text-xs text-muted-foreground">{sub}</div>}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── DashboardPage ────────────────────────────────────────────────────────────
 
 export default function DashboardPage() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+
+  const { summary: monthSummary, loading: summaryLoading } = useMonthlySummary(year, month);
+  const { analysis, loading: analysisLoading } = useBudgetAnalysis(year, month);
+  const { summary: portfolio, loading: portfolioLoading } = usePortfolioSummary();
+  const { holdings, loading: holdingsLoading } = useHoldings();
+  const { activities, loading: activitiesLoading } = useRecentActivity(10);
+
+  const gainRate = portfolio?.totalUnrealizedGainRate ?? 0;
+  const isGain = gainRate >= 0;
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">대시보드</h1>
+      <div>
+        <h1 className="text-2xl font-bold">대시보드</h1>
+        <p className="text-sm text-muted-foreground">{formatMonth(now)} 현황</p>
+      </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {/* Row 1: Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryCard
+          title="이번 달 수입"
+          icon={<TrendingUp className="h-4 w-4" />}
+          loading={summaryLoading}
+          value={
+            <AmountDisplay
+              amount={monthSummary?.totalIncome ?? 0}
+              className="text-2xl font-bold text-emerald-600 dark:text-emerald-400"
+            />
+          }
+        />
+        <SummaryCard
+          title="이번 달 지출"
+          icon={<TrendingDown className="h-4 w-4" />}
+          loading={summaryLoading}
+          value={
+            <AmountDisplay
+              amount={monthSummary?.totalExpense ?? 0}
+              className="text-2xl font-bold text-red-600 dark:text-red-400"
+            />
+          }
+          sub={
+            monthSummary
+              ? `저축 ${new Intl.NumberFormat('ko-KR').format(monthSummary.totalSaving)}원`
+              : undefined
+          }
+        />
+        <SummaryCard
+          title="포트폴리오 평가액"
+          icon={<Wallet className="h-4 w-4" />}
+          loading={portfolioLoading}
+          value={
+            <AmountDisplay
+              amount={portfolio?.totalEvaluation ?? 0}
+              className="text-2xl font-bold"
+            />
+          }
+          sub={
+            portfolio
+              ? `투자원금 ${new Intl.NumberFormat('ko-KR').format(portfolio.totalInvested)}원`
+              : undefined
+          }
+        />
+        <SummaryCard
+          title="미실현 손익"
+          icon={<PiggyBank className="h-4 w-4" />}
+          loading={portfolioLoading}
+          value={
+            <AmountDisplay
+              amount={portfolio?.totalUnrealizedGain ?? 0}
+              showSign
+              className={cn(
+                'text-2xl font-bold',
+                isGain
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'text-red-600 dark:text-red-400',
+              )}
+            />
+          }
+          sub={
+            portfolio
+              ? formatPercent(gainRate)
+              : undefined
+          }
+        />
+      </div>
+
+      {/* Row 2: Budget analysis + Holdings */}
+      <div className="grid gap-6 md:grid-cols-2">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">이번 달 수입</CardTitle>
+          <CardHeader>
+            <CardTitle className="text-base">예산 달성률</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
+            <BudgetSummary analysis={analysis} loading={analysisLoading} />
           </CardContent>
         </Card>
+
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">이번 달 지출</CardTitle>
+          <CardHeader>
+            <CardTitle className="text-base">보유 종목 요약</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">총 평가 금액</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">총 수익률</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-muted-foreground">-</div>
+            <HoldingsSummary holdings={holdings} loading={holdingsLoading} />
           </CardContent>
         </Card>
       </div>
 
+      {/* Row 3: Recent activity */}
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <LayoutDashboard className="h-5 w-5" />
-            요약
-          </CardTitle>
+          <CardTitle className="text-base">최근 활동</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            대시보드 데이터가 API 연동 후 표시됩니다.
-          </p>
+          <RecentActivity activities={activities} loading={activitiesLoading} />
         </CardContent>
       </Card>
     </div>

--- a/apps/web/components/dashboard/budget-summary.tsx
+++ b/apps/web/components/dashboard/budget-summary.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { BudgetAnalysisItem } from '@my-wallet/shared';
+import { BudgetProgress } from '@/components/budget/budget-progress';
+
+interface BudgetSummaryProps {
+  analysis: BudgetAnalysisItem[];
+  loading: boolean;
+}
+
+export function BudgetSummary({ analysis, loading }: BudgetSummaryProps) {
+  if (loading) {
+    return (
+      <div className="space-y-4 animate-pulse">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2 py-3">
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="h-3 w-8 rounded bg-muted" />
+            </div>
+            <div className="h-2 w-full rounded-full bg-muted" />
+            <div className="flex justify-between">
+              <div className="h-3 w-20 rounded bg-muted" />
+              <div className="h-3 w-20 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (analysis.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        이번 달 예산 데이터가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border">
+      {analysis.map((item) => (
+        <BudgetProgress key={item.categoryId} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/holdings-summary.tsx
+++ b/apps/web/components/dashboard/holdings-summary.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { HoldingItem } from '@my-wallet/shared';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { cn } from '@/lib/utils';
+
+interface HoldingsSummaryProps {
+  holdings: HoldingItem[];
+  loading: boolean;
+}
+
+export function HoldingsSummary({ holdings, loading }: HoldingsSummaryProps) {
+  if (loading) {
+    return (
+      <div className="space-y-3 animate-pulse">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="flex-1 space-y-1">
+              <div className="h-4 w-28 rounded bg-muted" />
+              <div className="h-3 w-16 rounded bg-muted" />
+            </div>
+            <div className="text-right space-y-1">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="h-3 w-12 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (holdings.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        보유 종목이 없습니다.
+      </p>
+    );
+  }
+
+  const top5 = holdings.slice(0, 5);
+
+  return (
+    <div className="divide-y divide-border">
+      {top5.map((holding) => {
+        const isGain = holding.unrealizedGain >= 0;
+        return (
+          <div key={holding.stockId} className="flex items-center gap-3 py-3">
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">{holding.stockName}</p>
+              <p className="text-xs text-muted-foreground">
+                {holding.stockCode} · {holding.weight.toFixed(1)}%
+              </p>
+            </div>
+            <div className="text-right shrink-0">
+              <AmountDisplay amount={holding.evaluation} className="block text-sm font-semibold" />
+              <span
+                className={cn(
+                  'text-xs font-medium',
+                  isGain ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400',
+                )}
+              >
+                {isGain ? '+' : ''}
+                {holding.unrealizedGainRate.toFixed(2)}%
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/recent-activity.tsx
+++ b/apps/web/components/dashboard/recent-activity.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { ActivityItem, ActivityType } from '@/hooks/use-dashboard';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { cn } from '@/lib/utils';
+
+// ─── Type badge ───────────────────────────────────────────────────────────────
+
+const typeConfig: Record<
+  ActivityType,
+  { label: string; className: string }
+> = {
+  INCOME: { label: '수입', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' },
+  EXPENSE: { label: '지출', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+  SAVING: { label: '저축', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  BUY: { label: '매수', className: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400' },
+  SELL: { label: '매도', className: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
+};
+
+function ActivityTypeBadge({ type }: { type: ActivityType }) {
+  const cfg = typeConfig[type];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold shrink-0',
+        cfg.className,
+      )}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+// ─── RecentActivity ───────────────────────────────────────────────────────────
+
+interface RecentActivityProps {
+  activities: ActivityItem[];
+  loading: boolean;
+}
+
+export function RecentActivity({ activities, loading }: RecentActivityProps) {
+  if (loading) {
+    return (
+      <ul className="divide-y divide-border">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <li key={i} className="flex items-center gap-3 py-3 animate-pulse">
+            <div className="h-5 w-10 rounded-md bg-muted" />
+            <div className="flex-1 space-y-1">
+              <div className="h-4 w-40 rounded bg-muted" />
+              <div className="h-3 w-20 rounded bg-muted" />
+            </div>
+            <div className="h-4 w-24 rounded bg-muted" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (activities.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">최근 활동이 없습니다.</p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border">
+      {activities.map((item) => (
+        <li key={item.id} className="flex items-center gap-3 py-3">
+          <ActivityTypeBadge type={item.type} />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{item.description}</p>
+            <p className="text-xs text-muted-foreground">{item.date}</p>
+          </div>
+          <AmountDisplay
+            amount={item.amount}
+            className="text-sm font-semibold tabular-nums"
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/hooks/use-dashboard.ts
+++ b/apps/web/hooks/use-dashboard.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { fetchTransactions, type Transaction } from '@/lib/api/budget';
+import { fetchTrades, type Trade } from '@/lib/api/stock';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ActivityType = 'INCOME' | 'EXPENSE' | 'SAVING' | 'BUY' | 'SELL';
+
+export interface ActivityItem {
+  id: string;
+  date: string;
+  type: ActivityType;
+  description: string;
+  amount: number;
+  source: 'budget' | 'stock';
+}
+
+interface UseRecentActivityReturn {
+  activities: ActivityItem[];
+  loading: boolean;
+  error: string | null;
+}
+
+// ─── useRecentActivity ────────────────────────────────────────────────────────
+
+export function useRecentActivity(limit = 10): UseRecentActivityReturn {
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetchTransactions({ limit: 20, page: 1 }).catch(() => ({ data: [] as Transaction[], total: 0, page: 1, limit: 20 })),
+      fetchTrades({ limit: 20, page: 1 }).catch(() => ({ data: [] as Trade[], total: 0, page: 1, limit: 20 })),
+    ])
+      .then(([txRes, tradeRes]) => {
+        if (cancelled) return;
+
+        const txItems: ActivityItem[] = txRes.data.map((tx) => ({
+          id: `tx-${tx.id}`,
+          date: tx.date,
+          type: tx.type as ActivityType,
+          description: tx.category?.name ? `${tx.category.name} · ${tx.title}` : tx.title,
+          amount: tx.amount,
+          source: 'budget',
+        }));
+
+        const tradeItems: ActivityItem[] = tradeRes.data.map((trade) => ({
+          id: `trade-${trade.id}`,
+          date: trade.tradeDate,
+          type: trade.type as ActivityType,
+          description: trade.stock?.name
+            ? `${trade.stock.name} (${trade.stock.code})`
+            : `주식 ${trade.type === 'BUY' ? '매수' : '매도'}`,
+          amount: trade.totalAmount,
+          source: 'stock',
+        }));
+
+        const merged = [...txItems, ...tradeItems]
+          .sort((a, b) => b.date.localeCompare(a.date))
+          .slice(0, limit);
+
+        setActivities(merged);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message ?? '최근 활동을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [limit]);
+
+  return { activities, loading, error };
+}


### PR DESCRIPTION
## Summary
- 통합 대시보드: 가계부 + 주식 핵심 지표 한눈에 확인
- Notion 데이터 마이그레이션 API 3개 엔드포인트
- 전체 테스트 190개 통과

## Changes

### Dashboard (#11)
- `hooks/use-dashboard.ts` — 최근 활동 통합 훅
- `components/dashboard/` — 3개 컴포넌트 (recent-activity, budget-summary, holdings-summary)
- `dashboard/page.tsx` — 수입/지출 요약, 예산 달성률, 포트폴리오 현황, 최근 활동

### Migration API (#12)
- `migration/migration.service.ts` — transactions/budgets/trades 벌크 임포트
- `migration/migration.controller.ts` — POST /migration/notion/* 3개 엔드포인트
- DTOs + 테스트 19개 (서비스 13 + 컨트롤러 6)
- `app.module.ts` — MigrationModule 등록

## Related Issues
Closes #11, Closes #12

## Test Plan
- [x] `npx jest` — 190/190 tests pass
- [x] `turbo build` — 4/4 tasks successful
- [ ] Manual: 대시보드 페이지에서 가계부+주식 데이터 통합 확인
- [ ] Manual: 마이그레이션 API로 샘플 데이터 임포트 테스트