### PR TITLE
release: 가계부 UX 개선 + 카테고리 관리

### DIFF
--- a/apps/api/src/budget/controllers/category.controller.ts
+++ b/apps/api/src/budget/controllers/category.controller.ts
@@ -1,7 +1,20 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { PrismaService } from '../../prisma/prisma.service';
+import { CreateCategoryDto } from '../dto/create-category.dto';
+import { UpdateCategoryDto } from '../dto/update-category.dto';
 
 @ApiTags('Categories')
 @ApiBearerAuth()
@@ -44,5 +57,79 @@ export class CategoryController {
       where: { isActive: true, type: 'SAVING' },
       orderBy: { sortOrder: 'asc' },
     });
+  }
+
+  @Post()
+  @ApiOperation({ summary: '카테고리 생성' })
+  async create(@Body() dto: CreateCategoryDto) {
+    const existing = await this.prisma.category.findUnique({
+      where: { name_type: { name: dto.name, type: dto.type } },
+    });
+    if (existing) {
+      if (!existing.isActive) {
+        // 비활성 카테고리 재활성화
+        return this.prisma.category.update({
+          where: { id: existing.id },
+          data: { isActive: true, sortOrder: dto.sortOrder ?? existing.sortOrder },
+        });
+      }
+      throw new HttpException(
+        '같은 유형에 동일한 이름의 카테고리가 이미 존재합니다.',
+        HttpStatus.CONFLICT,
+      );
+    }
+    return this.prisma.category.create({
+      data: {
+        name: dto.name,
+        type: dto.type,
+        sortOrder: dto.sortOrder ?? 0,
+      },
+    });
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '카테고리 수정' })
+  async update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
+    const category = await this.prisma.category.findUnique({ where: { id } });
+    if (!category) {
+      throw new HttpException('카테고리를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+    }
+    // 이름 변경 시 중복 체크
+    if (dto.name && dto.name !== category.name) {
+      const duplicate = await this.prisma.category.findUnique({
+        where: { name_type: { name: dto.name, type: category.type } },
+      });
+      if (duplicate && duplicate.id !== id) {
+        throw new HttpException(
+          '같은 유형에 동일한 이름의 카테고리가 이미 존재합니다.',
+          HttpStatus.CONFLICT,
+        );
+      }
+    }
+    return this.prisma.category.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '카테고리 삭제 (비활성화)' })
+  async remove(@Param('id') id: string) {
+    const category = await this.prisma.category.findUnique({
+      where: { id },
+      include: { _count: { select: { transactions: true, budgets: true } } },
+    });
+    if (!category) {
+      throw new HttpException('카테고리를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+    }
+    // 연결된 거래/예산이 있으면 soft delete
+    if (category._count.transactions > 0 || category._count.budgets > 0) {
+      return this.prisma.category.update({
+        where: { id },
+        data: { isActive: false },
+      });
+    }
+    // 연결된 데이터 없으면 하드 삭제
+    return this.prisma.category.delete({ where: { id } });
   }
 }

--- a/apps/api/src/budget/dto/create-category.dto.ts
+++ b/apps/api/src/budget/dto/create-category.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsEnum, IsOptional, IsInt, Min } from 'class-validator';
+
+export class CreateCategoryDto {
+  @ApiProperty({ description: '카테고리 이름', example: '식비' })
+  @IsString()
+  @IsNotEmpty({ message: '카테고리 이름은 필수 입력입니다.' })
+  name: string;
+
+  @ApiProperty({ description: '거래 유형', enum: ['INCOME', 'EXPENSE', 'SAVING'] })
+  @IsEnum(['INCOME', 'EXPENSE', 'SAVING'] as const, {
+    message: '유형은 INCOME, EXPENSE, SAVING 중 하나여야 합니다.',
+  })
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+
+  @ApiPropertyOptional({ description: '정렬 순서', default: 0 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}

--- a/apps/api/src/budget/dto/update-category.dto.ts
+++ b/apps/api/src/budget/dto/update-category.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsInt, Min, IsBoolean } from 'class-validator';
+
+export class UpdateCategoryDto {
+  @ApiPropertyOptional({ description: '카테고리 이름' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ description: '정렬 순서' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+
+  @ApiPropertyOptional({ description: '활성 상태' })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/apps/web/app/(main)/budget/page.tsx
+++ b/apps/web/app/(main)/budget/page.tsx
@@ -6,8 +6,31 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
 import { MonthPicker } from '@/components/common/month-picker';
 import { AmountDisplay } from '@/components/common/amount-display';
-import { useMonthlySummary } from '@/hooks/use-budget';
-import { Receipt, BarChart3, TrendingUp, TrendingDown, PiggyBank, Wallet } from 'lucide-react';
+import { BudgetProgress } from '@/components/budget/budget-progress';
+import { useMonthlySummary, useBudgetAnalysis, useTransactions } from '@/hooks/use-budget';
+import { getCategoryColor, getCategoryHex } from '@/lib/category-colors';
+import {
+  Receipt,
+  BarChart3,
+  TrendingUp,
+  TrendingDown,
+  PiggyBank,
+  Wallet,
+  ArrowRight,
+} from 'lucide-react';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import type { Transaction } from '@/lib/api/budget';
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
 
 export default function BudgetPage() {
   const [selectedDate, setSelectedDate] = useState(() => {
@@ -18,7 +41,35 @@ export default function BudgetPage() {
   const year = selectedDate.getFullYear();
   const month = selectedDate.getMonth() + 1;
 
-  const { summary, loading } = useMonthlySummary(year, month);
+  const { summary, loading: summaryLoading } = useMonthlySummary(year, month);
+  const { analysis, loading: analysisLoading } = useBudgetAnalysis(year, month);
+
+  // 최근 거래 5건: 해당 월의 첫날~마지막날 범위
+  const startDate = `${year}-${String(month).padStart(2, '0')}-01`;
+  const lastDay = new Date(year, month, 0).getDate();
+  const endDate = `${year}-${String(month).padStart(2, '0')}-${lastDay}`;
+  const { data: recentData, loading: recentLoading } = useTransactions({
+    page: 1,
+    limit: 5,
+    startDate,
+    endDate,
+  });
+  const recentTransactions = recentData?.data ?? [];
+
+  // 도넛 차트 데이터: 카테고리별 지출 집계
+  const expenseAnalysis = analysis.filter((a) => a.actual > 0);
+  const pieData = expenseAnalysis.map((item) => ({
+    name: item.categoryName,
+    value: item.actual,
+    color: getCategoryHex(item.categoryName),
+  }));
+
+  // 예산 진행률 TOP 5 (달성률 높은 순)
+  const topBudgets = [...analysis]
+    .sort((a, b) => b.achievementRate - a.achievementRate)
+    .slice(0, 5);
+
+  const loading = summaryLoading || analysisLoading;
 
   return (
     <div className="space-y-6">
@@ -107,6 +158,157 @@ export default function BudgetPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Charts Row: Donut + Budget Progress */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* 카테고리별 지출 도넛 차트 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">카테고리별 지출</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {analysisLoading ? (
+              <div className="h-48 bg-muted animate-pulse rounded" />
+            ) : pieData.length === 0 ? (
+              <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+                이번 달 지출 내역이 없습니다.
+              </div>
+            ) : (
+              <div className="flex items-center gap-4">
+                <ResponsiveContainer width="100%" height={200}>
+                  <PieChart>
+                    <Pie
+                      data={pieData}
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={50}
+                      outerRadius={80}
+                      paddingAngle={2}
+                      dataKey="value"
+                    >
+                      {pieData.map((entry, idx) => (
+                        <Cell key={idx} fill={entry.color} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      formatter={(value: number) =>
+                        new Intl.NumberFormat('ko-KR').format(value) + '원'
+                      }
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+                <div className="flex flex-col gap-1.5 text-xs min-w-0">
+                  {pieData.map((item) => (
+                    <div key={item.name} className="flex items-center gap-1.5">
+                      <div
+                        className="h-2.5 w-2.5 rounded-sm flex-shrink-0"
+                        style={{ backgroundColor: item.color }}
+                      />
+                      <span className="truncate">{item.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 예산 진행률 TOP 5 */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-base">예산 진행률</CardTitle>
+            <Link
+              href="/budget/analysis"
+              className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-0.5"
+            >
+              전체 보기 <ArrowRight className="h-3 w-3" />
+            </Link>
+          </CardHeader>
+          <CardContent>
+            {analysisLoading ? (
+              <div className="space-y-4">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-16 bg-muted animate-pulse rounded" />
+                ))}
+              </div>
+            ) : topBudgets.length === 0 ? (
+              <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+                설정된 예산이 없습니다.
+              </div>
+            ) : (
+              <div className="divide-y">
+                {topBudgets.map((item) => (
+                  <BudgetProgress key={item.categoryId} item={item} />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 최근 거래 */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Receipt className="h-4 w-4" />
+            최근 거래
+          </CardTitle>
+          <Link
+            href="/budget/transactions"
+            className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-0.5"
+          >
+            전체 보기 <ArrowRight className="h-3 w-3" />
+          </Link>
+        </CardHeader>
+        <CardContent>
+          {recentLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+              ))}
+            </div>
+          ) : recentTransactions.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground text-sm">
+              이번 달 거래 내역이 없습니다.
+              <Link
+                href="/budget/transactions"
+                className={buttonVariants({ variant: 'link', size: 'sm' })}
+              >
+                거래 추가하기
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {recentTransactions.map((tx: Transaction) => {
+                const color = getCategoryColor(tx.category?.name ?? '기타');
+                return (
+                  <div
+                    key={tx.id}
+                    className="flex items-center justify-between py-1.5"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-xs text-muted-foreground w-10 flex-shrink-0">
+                        {formatDate(tx.date)}
+                      </span>
+                      <span
+                        className={`text-xs px-1.5 py-0.5 rounded ${color.bg} ${color.text}`}
+                      >
+                        {tx.category?.name ?? '기타'}
+                      </span>
+                      <span className="text-sm truncate">{tx.title}</span>
+                    </div>
+                    <AmountDisplay
+                      amount={tx.type === 'EXPENSE' ? -tx.amount : tx.amount}
+                      showSign
+                      className="text-sm font-medium flex-shrink-0"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Quick links */}
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/app/(main)/budget/transactions/page.tsx
+++ b/apps/web/app/(main)/budget/transactions/page.tsx
@@ -11,7 +11,7 @@ import {
   SelectItem,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { TransactionTable } from '@/components/budget/transaction-table';
+import { TransactionTable, TransactionSkeleton } from '@/components/budget/transaction-table';
 import { TransactionForm } from '@/components/budget/transaction-form';
 import { useTransactions, useCategories } from '@/hooks/use-budget';
 import type { TransactionType } from '@my-wallet/shared';
@@ -154,9 +154,7 @@ export default function TransactionsPage() {
         </CardHeader>
         <CardContent className="p-0">
           {loading ? (
-            <div className="py-12 text-center text-muted-foreground text-sm">
-              불러오는 중...
-            </div>
+            <TransactionSkeleton />
           ) : error ? (
             <div className="py-12 text-center text-destructive text-sm">{error}</div>
           ) : (

--- a/apps/web/app/(main)/settings/page.tsx
+++ b/apps/web/app/(main)/settings/page.tsx
@@ -1,24 +1,269 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Settings } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  fetchCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  type Category,
+  type CreateCategoryDto,
+} from '@/lib/api/budget';
+import { getCategoryColor } from '@/lib/category-colors';
+import type { TransactionType } from '@my-wallet/shared';
+import { Settings, Plus, Pencil, Trash2, GripVertical } from 'lucide-react';
+
+const TYPE_LABELS: Record<TransactionType, string> = {
+  INCOME: '수입',
+  EXPENSE: '지출',
+  SAVING: '저축',
+};
+
+const TYPE_TABS: TransactionType[] = ['EXPENSE', 'INCOME', 'SAVING'];
 
 export default function SettingsPage() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<TransactionType>('EXPENSE');
+
+  // Form state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formType, setFormType] = useState<TransactionType>('EXPENSE');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadCategories = useCallback(async () => {
+    try {
+      const data = await fetchCategories();
+      setCategories(data);
+    } catch {
+      // 에러 무시
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCategories();
+  }, [loadCategories]);
+
+  const filtered = categories.filter((c) => c.type === activeTab);
+
+  const handleAdd = () => {
+    setEditingCategory(null);
+    setFormName('');
+    setFormType(activeTab);
+    setFormError(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (cat: Category) => {
+    setEditingCategory(cat);
+    setFormName(cat.name);
+    setFormType(cat.type);
+    setFormError(null);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (cat: Category) => {
+    if (!confirm(`"${cat.name}" 카테고리를 삭제하시겠습니까?`)) return;
+    try {
+      await deleteCategory(cat.id);
+      await loadCategories();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : '삭제에 실패했습니다.');
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formName.trim()) {
+      setFormError('카테고리 이름을 입력해주세요.');
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      if (editingCategory) {
+        await updateCategory(editingCategory.id, { name: formName.trim() });
+      } else {
+        const dto: CreateCategoryDto = {
+          name: formName.trim(),
+          type: formType,
+          sortOrder: filtered.length,
+        };
+        await createCategory(dto);
+      }
+      await loadCategories();
+      setFormOpen(false);
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : '저장에 실패했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">설정</h1>
 
+      {/* 카테고리 관리 */}
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="flex items-center gap-2">
             <Settings className="h-5 w-5" />
-            계정 설정
+            카테고리 관리
           </CardTitle>
+          <Button size="sm" onClick={handleAdd} className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            추가
+          </Button>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            계정 및 앱 설정이 API 연동 후 표시됩니다.
-          </p>
+          {/* 유형 탭 */}
+          <div className="flex gap-1 mb-4 bg-muted p-1 rounded-lg">
+            {TYPE_TABS.map((t) => (
+              <button
+                key={t}
+                onClick={() => setActiveTab(t)}
+                className={`flex-1 py-1.5 px-3 rounded-md text-sm font-medium transition-colors ${
+                  activeTab === t
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {TYPE_LABELS[t]}
+              </button>
+            ))}
+          </div>
+
+          {/* 카테고리 목록 */}
+          {loading ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-12 bg-muted animate-pulse rounded" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground text-sm">
+              {TYPE_LABELS[activeTab]} 카테고리가 없습니다.
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {filtered.map((cat) => {
+                const color = getCategoryColor(cat.name);
+                return (
+                  <div
+                    key={cat.id}
+                    className="group flex items-center justify-between py-2.5 px-3 rounded-md hover:bg-muted/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <GripVertical className="h-4 w-4 text-muted-foreground/40" />
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-md font-medium ${color.bg} ${color.text}`}
+                      >
+                        {cat.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleEdit(cat)}
+                        className="h-7 w-7"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(cat)}
+                        className="h-7 w-7 text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
+
+      {/* 카테고리 추가/수정 다이얼로그 */}
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {editingCategory ? '카테고리 수정' : '카테고리 추가'}
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {!editingCategory && (
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium">유형</label>
+                <Select value={formType} onValueChange={(v) => setFormType(v as TransactionType)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TYPE_TABS.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {TYPE_LABELS[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">이름</label>
+              <Input
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="카테고리 이름"
+                autoFocus
+              />
+            </div>
+            {formError && <p className="text-sm text-destructive">{formError}</p>}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setFormOpen(false)}
+                disabled={submitting}
+              >
+                취소
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? '저장 중...' : editingCategory ? '수정' : '추가'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/components/budget/transaction-form.tsx
+++ b/apps/web/components/budget/transaction-form.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { format, parse } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import type { TransactionType } from '@my-wallet/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,6 +20,10 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { CalendarIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { Transaction, Category, CreateTransactionDto, UpdateTransactionDto } from '@/lib/api/budget';
 
 interface TransactionFormProps {
@@ -58,7 +64,7 @@ export function TransactionForm({
       setType(transaction.type);
       setCategoryId(transaction.categoryId);
       setTitle(transaction.title);
-      setAmount(String(transaction.amount));
+      setAmount(transaction.amount.toLocaleString('ko-KR'));
       setDate(transaction.date.slice(0, 10));
       setIsFixed(transaction.isFixed);
       setMemo(transaction.memo ?? '');
@@ -165,22 +171,48 @@ export function TransactionForm({
           <div className="space-y-1.5">
             <label className="text-sm font-medium">금액 (원)</label>
             <Input
-              type="number"
+              type="text"
+              inputMode="numeric"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => {
+                const raw = e.target.value.replace(/[^0-9]/g, '');
+                if (raw === '') { setAmount(''); return; }
+                setAmount(Number(raw).toLocaleString('ko-KR'));
+              }}
               placeholder="0"
-              min={1}
             />
           </div>
 
           {/* Date */}
           <div className="space-y-1.5">
             <label className="text-sm font-medium">날짜</label>
-            <Input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-            />
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className={cn(
+                    'w-full justify-start text-left font-normal',
+                    !date && 'text-muted-foreground',
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {date
+                    ? format(parse(date, 'yyyy-MM-dd', new Date()), 'yyyy년 M월 d일', { locale: ko })
+                    : '날짜 선택'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={date ? parse(date, 'yyyy-MM-dd', new Date()) : undefined}
+                  onSelect={(day) => {
+                    if (day) setDate(format(day, 'yyyy-MM-dd'));
+                  }}
+                  defaultMonth={date ? parse(date, 'yyyy-MM-dd', new Date()) : undefined}
+                />
+              </PopoverContent>
+            </Popover>
           </div>
 
           {/* isFixed */}

--- a/apps/web/components/budget/transaction-table.tsx
+++ b/apps/web/components/budget/transaction-table.tsx
@@ -2,18 +2,11 @@
 
 import type { TransactionType } from '@my-wallet/shared';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from '@/components/ui/table';
 import { AmountDisplay } from '@/components/common/amount-display';
+import { getCategoryColor } from '@/lib/category-colors';
+import { groupByDate } from '@/lib/date-utils';
 import type { Transaction } from '@/lib/api/budget';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
 
 interface TransactionTableProps {
   transactions: Transaction[];
@@ -27,85 +20,158 @@ const TYPE_LABELS: Record<TransactionType, string> = {
   SAVING: '저축',
 };
 
-const TYPE_VARIANTS: Record<TransactionType, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  INCOME: 'default',
-  EXPENSE: 'destructive',
-  SAVING: 'secondary',
-};
+/** 스켈레톤 UI: 로딩 중 표시 */
+export function TransactionSkeleton() {
+  return (
+    <div className="space-y-6 p-4">
+      {[1, 2, 3].map((group) => (
+        <div key={group} className="space-y-3">
+          <div className="h-4 w-32 bg-muted animate-pulse rounded" />
+          {[1, 2].map((item) => (
+            <div key={item} className="flex items-center justify-between py-3">
+              <div className="flex items-center gap-3">
+                <div className="h-6 w-12 bg-muted animate-pulse rounded" />
+                <div className="space-y-1">
+                  <div className="h-4 w-24 bg-muted animate-pulse rounded" />
+                  <div className="h-3 w-16 bg-muted animate-pulse rounded" />
+                </div>
+              </div>
+              <div className="h-5 w-20 bg-muted animate-pulse rounded" />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
 
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+/** 빈 상태 안내 */
+export function TransactionEmpty({ onAdd }: { onAdd?: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="rounded-full bg-muted p-4 mb-4">
+        <Plus className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <p className="text-muted-foreground text-sm mb-1">
+        아직 거래가 없어요.
+      </p>
+      <p className="text-muted-foreground text-xs mb-4">
+        추가 버튼으로 첫 거래를 입력해보세요.
+      </p>
+      {onAdd && (
+        <Button size="sm" onClick={onAdd} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          거래 추가
+        </Button>
+      )}
+    </div>
+  );
 }
 
 export function TransactionTable({ transactions, onEdit, onDelete }: TransactionTableProps) {
   if (transactions.length === 0) {
-    return (
-      <div className="py-12 text-center text-muted-foreground text-sm">
-        거래 내역이 없습니다.
-      </div>
-    );
+    return <TransactionEmpty />;
   }
 
+  const groups = groupByDate(transactions);
+
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>날짜</TableHead>
-          <TableHead>카테고리</TableHead>
-          <TableHead>제목</TableHead>
-          <TableHead>유형</TableHead>
-          <TableHead className="text-right">금액</TableHead>
-          <TableHead className="w-20"></TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {transactions.map((tx) => (
-          <TableRow key={tx.id}>
-            <TableCell className="text-muted-foreground whitespace-nowrap">
-              {formatDate(tx.date)}
-            </TableCell>
-            <TableCell>{tx.category?.name ?? '-'}</TableCell>
-            <TableCell>
-              <span>{tx.title}</span>
-              {tx.isFixed && (
-                <span className="ml-1.5 text-xs text-muted-foreground">(고정)</span>
-              )}
-            </TableCell>
-            <TableCell>
-              <Badge variant={TYPE_VARIANTS[tx.type]}>{TYPE_LABELS[tx.type]}</Badge>
-            </TableCell>
-            <TableCell className="text-right">
+    <div className="divide-y">
+      {groups.map((group) => {
+        const groupTotal = group.items.reduce((sum, tx) => {
+          return sum + (tx.type === 'EXPENSE' ? -tx.amount : tx.amount);
+        }, 0);
+
+        return (
+          <div key={group.date} className="py-3 px-4">
+            {/* 날짜 헤더 */}
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                {group.label}
+              </span>
               <AmountDisplay
-                amount={tx.type === 'EXPENSE' ? -tx.amount : tx.amount}
+                amount={groupTotal}
                 showSign
+                className="text-xs"
               />
-            </TableCell>
-            <TableCell>
-              <div className="flex items-center gap-1 justify-end">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onEdit(tx)}
-                  aria-label="수정"
-                  className="h-7 w-7"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onDelete(tx.id)}
-                  aria-label="삭제"
-                  className="h-7 w-7 text-destructive hover:text-destructive"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+            </div>
+
+            {/* 거래 목록 */}
+            <div className="space-y-1">
+              {group.items.map((tx) => {
+                const color = getCategoryColor(tx.category?.name ?? '기타');
+                return (
+                  <div
+                    key={tx.id}
+                    className="group flex items-center justify-between py-2 px-2 -mx-2 rounded-md hover:bg-muted/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      {/* 카테고리 뱃지 */}
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-md font-medium flex-shrink-0 ${color.bg} ${color.text}`}
+                      >
+                        {TYPE_LABELS[tx.type]}
+                      </span>
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-medium truncate">
+                            {tx.title}
+                          </span>
+                          {tx.isFixed && (
+                            <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
+                              고정
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <span className={`${color.text}`}>
+                            {tx.category?.name ?? '기타'}
+                          </span>
+                          {tx.memo && (
+                            <>
+                              <span>·</span>
+                              <span className="truncate">{tx.memo}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <AmountDisplay
+                        amount={tx.type === 'EXPENSE' ? -tx.amount : tx.amount}
+                        showSign
+                        className="text-sm font-semibold"
+                      />
+                      {/* 편집/삭제 버튼: hover 시 표시 */}
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEdit(tx)}
+                          aria-label="수정"
+                          className="h-7 w-7"
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onDelete(tx.id)}
+                          aria-label="삭제"
+                          className="h-7 w-7 text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
+import { ko } from 'date-fns/locale';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
+
+type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({ className, classNames, ...props }: CalendarProps) {
+  return (
+    <DayPicker
+      locale={ko}
+      className={cn('p-3', className)}
+      classNames={{
+        months: 'flex flex-col sm:flex-row gap-2',
+        month: 'flex flex-col gap-4',
+        month_caption: 'flex justify-center pt-1 relative items-center text-sm font-medium',
+        nav: 'flex items-center gap-1',
+        button_previous: cn(
+          buttonVariants({ variant: 'outline' }),
+          'absolute left-1 top-0 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+        ),
+        button_next: cn(
+          buttonVariants({ variant: 'outline' }),
+          'absolute right-1 top-0 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+        ),
+        month_grid: 'w-full border-collapse space-y-1',
+        weekdays: 'flex',
+        weekday: 'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
+        week: 'flex w-full mt-2',
+        day: cn(
+          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20',
+          '[&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50',
+          '[&:has([aria-selected].day-range-end)]:rounded-r-md',
+        ),
+        day_button: cn(
+          buttonVariants({ variant: 'ghost' }),
+          'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+        ),
+        range_end: 'day-range-end',
+        selected:
+          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-md',
+        today: 'bg-accent text-accent-foreground rounded-md',
+        outside:
+          'day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground',
+        disabled: 'text-muted-foreground opacity-50',
+        hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation }) =>
+          orientation === 'left' ? (
+            <ChevronLeft className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          ),
+      }}
+      {...props}
+    />
+  );
+}
+
+Calendar.displayName = 'Calendar';
+
+export { Calendar };
+export type { CalendarProps };

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/apps/web/hooks/use-budget.ts
+++ b/apps/web/hooks/use-budget.ts
@@ -67,26 +67,77 @@ export function useTransactions(filters: TransactionFilters = {}): UseTransactio
 
   const create = useCallback(
     async (dto: CreateTransactionDto) => {
-      await createTransaction(dto);
-      refetch();
+      const prev = data;
+      // Optimistic: 임시 항목 추가
+      const tempTx: Transaction = {
+        id: `temp-${Date.now()}`,
+        categoryId: dto.categoryId,
+        type: dto.type,
+        title: dto.title,
+        amount: dto.amount,
+        date: dto.date,
+        isFixed: dto.isFixed ?? false,
+        memo: dto.memo,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      if (prev) {
+        setData({ ...prev, data: [tempTx, ...prev.data], total: prev.total + 1 });
+      }
+      try {
+        await createTransaction(dto);
+        refetch(); // 서버 데이터로 교체
+      } catch (err) {
+        setData(prev); // 롤백
+        throw err;
+      }
     },
-    [refetch],
+    [data, refetch],
   );
 
   const update = useCallback(
     async (id: string, dto: UpdateTransactionDto) => {
-      await updateTransaction(id, dto);
-      refetch();
+      const prev = data;
+      // Optimistic: 해당 항목 즉시 업데이트
+      if (prev) {
+        setData({
+          ...prev,
+          data: prev.data.map((tx) =>
+            tx.id === id ? { ...tx, ...dto, updatedAt: new Date().toISOString() } : tx,
+          ),
+        });
+      }
+      try {
+        await updateTransaction(id, dto);
+        refetch();
+      } catch (err) {
+        setData(prev);
+        throw err;
+      }
     },
-    [refetch],
+    [data, refetch],
   );
 
   const remove = useCallback(
     async (id: string) => {
-      await deleteTransaction(id);
-      refetch();
+      const prev = data;
+      // Optimistic: 해당 항목 즉시 제거
+      if (prev) {
+        setData({
+          ...prev,
+          data: prev.data.filter((tx) => tx.id !== id),
+          total: prev.total - 1,
+        });
+      }
+      try {
+        await deleteTransaction(id);
+        refetch();
+      } catch (err) {
+        setData(prev);
+        throw err;
+      }
     },
-    [refetch],
+    [data, refetch],
   );
 
   return { data, loading, error, refetch, create, update, remove };

--- a/apps/web/lib/api/budget.ts
+++ b/apps/web/lib/api/budget.ts
@@ -128,6 +128,30 @@ export function fetchSavingCategories(): Promise<Category[]> {
   return apiClient.get<Category[]>('/categories/saving');
 }
 
+export interface CreateCategoryDto {
+  name: string;
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+  sortOrder?: number;
+}
+
+export interface UpdateCategoryDto {
+  name?: string;
+  sortOrder?: number;
+  isActive?: boolean;
+}
+
+export function createCategory(dto: CreateCategoryDto): Promise<Category> {
+  return apiClient.post<Category>('/categories', dto);
+}
+
+export function updateCategory(id: string, dto: UpdateCategoryDto): Promise<Category> {
+  return apiClient.put<Category>(`/categories/${id}`, dto);
+}
+
+export function deleteCategory(id: string): Promise<void> {
+  return apiClient.delete<void>(`/categories/${id}`);
+}
+
 // ─── Summary API ──────────────────────────────────────────────────────────────
 
 export function fetchMonthlySummary(year: number, month: number): Promise<MonthSummary> {

--- a/apps/web/lib/category-colors.ts
+++ b/apps/web/lib/category-colors.ts
@@ -1,0 +1,43 @@
+/**
+ * 카테고리 이름 → Tailwind 색상 매핑
+ * 도넛 차트, 카드형 리스트의 카테고리 뱃지에서 사용
+ */
+
+// 카테고리 이름 → [bg class, text class, hex (차트용)]
+const CATEGORY_COLOR_MAP: Record<string, [bg: string, text: string, hex: string]> = {
+  // EXPENSE (쓰자)
+  식비: ['bg-blue-100', 'text-blue-700', '#3b82f6'],
+  교통비: ['bg-green-100', 'text-green-700', '#22c55e'],
+  통신비: ['bg-purple-100', 'text-purple-700', '#a855f7'],
+  월세: ['bg-orange-100', 'text-orange-700', '#f97316'],
+  생활비: ['bg-cyan-100', 'text-cyan-700', '#06b6d4'],
+  경조비: ['bg-pink-100', 'text-pink-700', '#ec4899'],
+  문화비: ['bg-indigo-100', 'text-indigo-700', '#6366f1'],
+  공과금: ['bg-amber-100', 'text-amber-700', '#f59e0b'],
+  '동생 기여금': ['bg-rose-100', 'text-rose-700', '#f43f5e'],
+  // SAVING (모으자)
+  보험: ['bg-emerald-100', 'text-emerald-700', '#10b981'],
+  청약저축: ['bg-teal-100', 'text-teal-700', '#14b8a6'],
+  연금저축: ['bg-sky-100', 'text-sky-700', '#0ea5e9'],
+  투자: ['bg-violet-100', 'text-violet-700', '#8b5cf6'],
+  // INCOME
+  급여: ['bg-lime-100', 'text-lime-700', '#84cc16'],
+  // fallback
+  기타: ['bg-gray-100', 'text-gray-700', '#6b7280'],
+};
+
+const FALLBACK: [string, string, string] = ['bg-gray-100', 'text-gray-700', '#6b7280'];
+
+export function getCategoryColor(name: string): { bg: string; text: string; hex: string } {
+  const [bg, text, hex] = CATEGORY_COLOR_MAP[name] ?? FALLBACK;
+  return { bg, text, hex };
+}
+
+export function getCategoryHex(name: string): string {
+  return (CATEGORY_COLOR_MAP[name] ?? FALLBACK)[2];
+}
+
+/** 도넛 차트용: 카테고리 배열에 대한 색상 배열 반환 */
+export function getCategoryColors(names: string[]): string[] {
+  return names.map(getCategoryHex);
+}

--- a/apps/web/lib/date-utils.ts
+++ b/apps/web/lib/date-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * 거래 내역을 날짜별로 그루핑하는 유틸리티
+ */
+
+export interface DateGroup<T> {
+  date: string; // YYYY-MM-DD
+  label: string; // "2026년 3월 27일"
+  items: T[];
+}
+
+/**
+ * 날짜 문자열(ISO)에서 YYYY-MM-DD 추출
+ */
+function toDateKey(dateStr: string): string {
+  return dateStr.slice(0, 10);
+}
+
+/**
+ * YYYY-MM-DD → "2026년 3월 27일" 형식
+ */
+function formatDateLabel(dateKey: string): string {
+  const [y, m, d] = dateKey.split('-').map(Number);
+  return `${y}년 ${m}월 ${d}일`;
+}
+
+/**
+ * 날짜 필드를 가진 아이템 배열을 날짜별로 그루핑
+ * 최신 날짜가 먼저 오도록 정렬
+ */
+export function groupByDate<T extends { date: string }>(items: T[]): DateGroup<T>[] {
+  const map = new Map<string, T[]>();
+
+  for (const item of items) {
+    const key = toDateKey(item.date);
+    const group = map.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([date, items]) => ({
+      date,
+      label: formatDateLabel(date),
+      items,
+    }));
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,14 +10,17 @@
   },
   "dependencies": {
     "@my-wallet/shared": "workspace:*",
+    "@radix-ui/react-popover": "^1.1.15",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.469.0",
     "next": "^15.3.0",
     "react": "^19.0.0",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.0",
-    "clsx": "^2.1.0",
-    "tailwind-merge": "^3.0.0",
-    "class-variance-authority": "^0.7.0",
-    "lucide-react": "^0.469.0"
+    "tailwind-merge": "^3.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.0",

--- a/packages/database/prisma/migrations/20260409000000_rename_categories/migration.sql
+++ b/packages/database/prisma/migrations/20260409000000_rename_categories/migration.sql
@@ -1,0 +1,20 @@
+-- 카테고리명 원본 반영: Notion 예산표 기준
+-- 거래/예산은 categoryId(FK)로 연결되어 있어 이름 변경만으로 안전
+
+-- EXPENSE 카테고리 이름 변경
+UPDATE "Category" SET name = '교통비' WHERE name = '교통' AND type = 'EXPENSE';
+UPDATE "Category" SET name = '통신비' WHERE name = '통신' AND type = 'EXPENSE';
+UPDATE "Category" SET name = '생활비' WHERE name = '생활' AND type = 'EXPENSE';
+UPDATE "Category" SET name = '경조비' WHERE name = '경조' AND type = 'EXPENSE';
+UPDATE "Category" SET name = '문화비' WHERE name = '문화' AND type = 'EXPENSE';
+
+-- SAVING 카테고리 이름 변경
+UPDATE "Category" SET name = '청약저축' WHERE name = '청약' AND type = 'SAVING';
+UPDATE "Category" SET name = '연금저축' WHERE name = '연금' AND type = 'SAVING';
+
+-- 새 카테고리 추가 (없으면 생성)
+INSERT INTO "Category" (id, name, type, sort_order, is_active)
+SELECT 'cat_sibling_contrib', '동생 기여금', 'EXPENSE', 9, true
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Category" WHERE name = '동생 기여금' AND type = 'EXPENSE'
+);

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -19,20 +19,21 @@ async function main() {
   // 2. 카테고리 생성
   const expenseCategories = [
     { name: '식비', sortOrder: 1 },
-    { name: '교통', sortOrder: 2 },
-    { name: '통신', sortOrder: 3 },
+    { name: '교통비', sortOrder: 2 },
+    { name: '통신비', sortOrder: 3 },
     { name: '월세', sortOrder: 4 },
-    { name: '생활', sortOrder: 5 },
-    { name: '경조', sortOrder: 6 },
-    { name: '문화', sortOrder: 7 },
+    { name: '생활비', sortOrder: 5 },
+    { name: '경조비', sortOrder: 6 },
+    { name: '문화비', sortOrder: 7 },
     { name: '공과금', sortOrder: 8 },
+    { name: '동생 기여금', sortOrder: 9 },
     { name: '기타', sortOrder: 99 },
   ];
 
   const savingCategories = [
     { name: '보험', sortOrder: 1 },
-    { name: '청약', sortOrder: 2 },
-    { name: '연금', sortOrder: 3 },
+    { name: '청약저축', sortOrder: 2 },
+    { name: '연금저축', sortOrder: 3 },
     { name: '투자', sortOrder: 4 },
   ];
 

--- a/packages/shared/src/constants/categories.ts
+++ b/packages/shared/src/constants/categories.ts
@@ -1,7 +1,7 @@
 export const EXPENSE_CATEGORIES = [
-  '식비', '교통', '통신', '월세', '생활', '경조', '문화', '공과금', '기타',
+  '식비', '교통비', '통신비', '월세', '생활비', '경조비', '문화비', '공과금', '동생 기여금', '기타',
 ] as const;
 
-export const SAVING_CATEGORIES = ['보험', '청약', '연금', '투자'] as const;
+export const SAVING_CATEGORIES = ['보험', '청약저축', '연금저축', '투자'] as const;
 
 export const INCOME_CATEGORIES = ['급여', '기타'] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,18 @@ importers:
       '@my-wallet/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@19.2.4)
@@ -120,6 +126,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.4
+      react-day-picker:
+        specifier: ^9.14.0
+        version: 9.14.0(react@19.2.4)
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
@@ -396,6 +405,9 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
@@ -554,6 +566,21 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1161,6 +1188,224 @@ packages:
   '@prisma/get-platform@6.19.2':
     resolution: {integrity: sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -1178,6 +1423,10 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -1581,6 +1830,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
@@ -1908,6 +2161,12 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1956,6 +2215,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -2184,6 +2446,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -3023,6 +3289,12 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -3034,11 +3306,41 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -3461,6 +3763,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3811,6 +4133,8 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@date-fns/tz@1.4.1': {}
+
   '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
@@ -3893,6 +4217,23 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -4528,6 +4869,193 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.19.2
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
+
   '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.27.10': {}
@@ -4545,6 +5073,8 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tabby_ai/hijri-converter@1.0.5': {}
 
   '@tailwindcss/node@4.2.2':
     dependencies:
@@ -4962,6 +5492,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   array-timsort@1.0.3: {}
 
   babel-jest@29.7.0(@babel/core@7.29.0):
@@ -5309,6 +5843,10 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -5334,6 +5872,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   diff-sequences@29.6.3: {}
 
@@ -5611,6 +6151,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -6565,6 +7107,14 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
 
+  react-day-picker@9.14.0(react@19.2.4):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.4
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -6574,6 +7124,25 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-smooth@4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       fast-equals: 5.4.0
@@ -6581,6 +7150,14 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -7008,6 +7585,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

develop → main 릴리스. PR #22 포함.

- /budget 메인 리디자인 (도넛차트 + 최근 거래 + 예산 진행률)
- /budget/transactions 카드형 리스트 + 스켈레톤
- 거래 추가 모달 Calendar + 금액 콤마 포맷 + Optimistic update
- 카테고리 CRUD API + 설정 페이지
- 카테고리명 DB 마이그레이션 (교통비, 통신비, 생활비 등 원본 반영)

## Deploy note
배포 후 `prisma migrate deploy` 실행 필요 (카테고리명 변경 마이그레이션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)