### PR TITLE
fix(budget): 도넛차트 + 필터 + 캘린더 정렬 수정

### DIFF
--- a/apps/api/src/budget/controllers/transaction.controller.ts
+++ b/apps/api/src/budget/controllers/transaction.controller.ts
@@ -58,6 +58,16 @@ export class TransactionController {
     return this.transactionService.getMonthlySummary(req.user.id, year, month);
   }
 
+  @Get('breakdown/:year/:month')
+  @ApiOperation({ summary: '월별 카테고리별 지출/수입/저축 집계' })
+  getCategoryBreakdown(
+    @Request() req: { user: { id: string } },
+    @Param('year') year: number,
+    @Param('month') month: number,
+  ) {
+    return this.transactionService.getCategoryBreakdown(req.user.id, year, month);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: '거래 내역 상세 조회' })
   findOne(

--- a/apps/api/src/budget/services/transaction.service.ts
+++ b/apps/api/src/budget/services/transaction.service.ts
@@ -157,4 +157,38 @@ export class TransactionService {
       balance: totalIncome - totalExpense - totalSaving,
     };
   }
+
+  async getCategoryBreakdown(userId: string, year: number, month: number) {
+    const monthStr = `${year}-${String(month).padStart(2, '0')}`;
+    const startDate = new Date(`${monthStr}-01`);
+    const nextMonthDate = new Date(startDate);
+    nextMonthDate.setUTCMonth(nextMonthDate.getUTCMonth() + 1);
+    nextMonthDate.setUTCDate(nextMonthDate.getUTCDate() - 1);
+    const endDate = nextMonthDate;
+
+    const transactions = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        date: { gte: startDate, lte: endDate },
+      },
+      include: { category: true },
+    });
+
+    const map = new Map<string, { categoryName: string; type: string; amount: number }>();
+    for (const tx of transactions) {
+      const key = tx.categoryId;
+      const existing = map.get(key);
+      if (existing) {
+        existing.amount += tx.amount;
+      } else {
+        map.set(key, {
+          categoryName: tx.category.name,
+          type: tx.type,
+          amount: tx.amount,
+        });
+      }
+    }
+
+    return Array.from(map.values()).sort((a, b) => b.amount - a.amount);
+  }
 }

--- a/apps/web/app/(main)/budget/page.tsx
+++ b/apps/web/app/(main)/budget/page.tsx
@@ -7,7 +7,7 @@ import { buttonVariants } from '@/components/ui/button';
 import { MonthPicker } from '@/components/common/month-picker';
 import { AmountDisplay } from '@/components/common/amount-display';
 import { BudgetProgress } from '@/components/budget/budget-progress';
-import { useMonthlySummary, useBudgetAnalysis, useTransactions } from '@/hooks/use-budget';
+import { useMonthlySummary, useBudgetAnalysis, useCategoryBreakdown, useTransactions } from '@/hooks/use-budget';
 import { getCategoryColor, getCategoryHex } from '@/lib/category-colors';
 import {
   Receipt,
@@ -43,6 +43,7 @@ export default function BudgetPage() {
 
   const { summary, loading: summaryLoading } = useMonthlySummary(year, month);
   const { analysis, loading: analysisLoading } = useBudgetAnalysis(year, month);
+  const { breakdown, loading: breakdownLoading } = useCategoryBreakdown(year, month);
 
   // 최근 거래 5건: 해당 월의 첫날~마지막날 범위
   const startDate = `${year}-${String(month).padStart(2, '0')}-01`;
@@ -56,11 +57,11 @@ export default function BudgetPage() {
   });
   const recentTransactions = recentData?.data ?? [];
 
-  // 도넛 차트 데이터: 카테고리별 지출 집계
-  const expenseAnalysis = analysis.filter((a) => a.actual > 0);
-  const pieData = expenseAnalysis.map((item) => ({
+  // 도넛 차트 데이터: 실제 거래 기반 카테고리별 지출 집계
+  const expenseBreakdown = breakdown.filter((b) => b.type === 'EXPENSE');
+  const pieData = expenseBreakdown.map((item) => ({
     name: item.categoryName,
-    value: item.actual,
+    value: item.amount,
     color: getCategoryHex(item.categoryName),
   }));
 
@@ -167,7 +168,7 @@ export default function BudgetPage() {
             <CardTitle className="text-base">카테고리별 지출</CardTitle>
           </CardHeader>
           <CardContent>
-            {analysisLoading ? (
+            {breakdownLoading ? (
               <div className="h-48 bg-muted animate-pulse rounded" />
             ) : pieData.length === 0 ? (
               <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">

--- a/apps/web/app/(main)/budget/transactions/page.tsx
+++ b/apps/web/app/(main)/budget/transactions/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { format, parse } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -10,13 +12,15 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select';
-import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
 import { TransactionTable, TransactionSkeleton } from '@/components/budget/transaction-table';
 import { TransactionForm } from '@/components/budget/transaction-form';
 import { useTransactions, useCategories } from '@/hooks/use-budget';
+import { cn } from '@/lib/utils';
 import type { TransactionType } from '@my-wallet/shared';
 import type { Transaction, TransactionFilters, CreateTransactionDto, UpdateTransactionDto } from '@/lib/api/budget';
-import { Plus, Receipt, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Plus, Receipt, ChevronLeft, ChevronRight, CalendarIcon, X } from 'lucide-react';
 
 const TYPE_LABELS: Record<string, string> = {
   ALL: '전체',
@@ -36,6 +40,8 @@ export default function TransactionsPage() {
   const [categoryFilter, setCategoryFilter] = useState<string>('ALL');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [startCalOpen, setStartCalOpen] = useState(false);
+  const [endCalOpen, setEndCalOpen] = useState(false);
   const [page, setPage] = useState(1);
 
   const filters: TransactionFilters = {
@@ -121,21 +127,91 @@ export default function TransactionsPage() {
             </Select>
 
             {/* Start date */}
-            <Input
-              type="date"
-              value={startDate}
-              onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
-              placeholder="시작일"
-            />
+            <Popover open={startCalOpen} onOpenChange={setStartCalOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'w-full justify-start text-left font-normal',
+                    !startDate && 'text-muted-foreground',
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {startDate
+                    ? format(parse(startDate, 'yyyy-MM-dd', new Date()), 'yyyy.MM.dd', { locale: ko })
+                    : '시작일'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={startDate ? parse(startDate, 'yyyy-MM-dd', new Date()) : undefined}
+                  onSelect={(day) => {
+                    if (day) { setStartDate(format(day, 'yyyy-MM-dd')); setPage(1); }
+                    setStartCalOpen(false);
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
 
             {/* End date */}
-            <Input
-              type="date"
-              value={endDate}
-              onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
-              placeholder="종료일"
-            />
+            <Popover open={endCalOpen} onOpenChange={setEndCalOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'w-full justify-start text-left font-normal',
+                    !endDate && 'text-muted-foreground',
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {endDate
+                    ? format(parse(endDate, 'yyyy-MM-dd', new Date()), 'yyyy.MM.dd', { locale: ko })
+                    : '종료일'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={endDate ? parse(endDate, 'yyyy-MM-dd', new Date()) : undefined}
+                  onSelect={(day) => {
+                    if (day) { setEndDate(format(day, 'yyyy-MM-dd')); setPage(1); }
+                    setEndCalOpen(false);
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
           </div>
+
+          {/* 필터 초기화 */}
+          {(typeFilter !== 'ALL' || categoryFilter !== 'ALL' || startDate || endDate) && (
+            <div className="mt-3 flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">적용된 필터:</span>
+              {typeFilter !== 'ALL' && (
+                <Button variant="secondary" size="sm" className="h-6 text-xs gap-1 px-2" onClick={() => { setTypeFilter('ALL'); setCategoryFilter('ALL'); setPage(1); }}>
+                  {TYPE_LABELS[typeFilter]} <X className="h-3 w-3" />
+                </Button>
+              )}
+              {categoryFilter !== 'ALL' && (
+                <Button variant="secondary" size="sm" className="h-6 text-xs gap-1 px-2" onClick={() => { setCategoryFilter('ALL'); setPage(1); }}>
+                  {filteredByType.find((c) => c.id === categoryFilter)?.name ?? '카테고리'} <X className="h-3 w-3" />
+                </Button>
+              )}
+              {startDate && (
+                <Button variant="secondary" size="sm" className="h-6 text-xs gap-1 px-2" onClick={() => { setStartDate(''); setPage(1); }}>
+                  {startDate} ~ <X className="h-3 w-3" />
+                </Button>
+              )}
+              {endDate && (
+                <Button variant="secondary" size="sm" className="h-6 text-xs gap-1 px-2" onClick={() => { setEndDate(''); setPage(1); }}>
+                  ~ {endDate} <X className="h-3 w-3" />
+                </Button>
+              )}
+              <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={() => { setTypeFilter('ALL'); setCategoryFilter('ALL'); setStartDate(''); setEndDate(''); setPage(1); }}>
+                전체 초기화
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/apps/web/components/budget/transaction-form.tsx
+++ b/apps/web/components/budget/transaction-form.tsx
@@ -56,6 +56,7 @@ export function TransactionForm({
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [isFixed, setIsFixed] = useState(false);
   const [memo, setMemo] = useState('');
+  const [calendarOpen, setCalendarOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -186,7 +187,7 @@ export function TransactionForm({
           {/* Date */}
           <div className="space-y-1.5">
             <label className="text-sm font-medium">날짜</label>
-            <Popover>
+            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
               <PopoverTrigger asChild>
                 <Button
                   type="button"
@@ -208,6 +209,7 @@ export function TransactionForm({
                   selected={date ? parse(date, 'yyyy-MM-dd', new Date()) : undefined}
                   onSelect={(day) => {
                     if (day) setDate(format(day, 'yyyy-MM-dd'));
+                    setCalendarOpen(false);
                   }}
                   defaultMonth={date ? parse(date, 'yyyy-MM-dd', new Date()) : undefined}
                 />

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -13,6 +13,8 @@ function Calendar({ className, classNames, ...props }: CalendarProps) {
   return (
     <DayPicker
       locale={ko}
+      weekStartsOn={0}
+      fixedWeeks
       className={cn('p-3', className)}
       classNames={{
         months: 'flex flex-col sm:flex-row gap-2',
@@ -27,15 +29,11 @@ function Calendar({ className, classNames, ...props }: CalendarProps) {
           buttonVariants({ variant: 'outline' }),
           'absolute right-1 top-0 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
         ),
-        month_grid: 'w-full border-collapse space-y-1',
-        weekdays: 'flex',
-        weekday: 'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
-        week: 'flex w-full mt-2',
-        day: cn(
-          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20',
-          '[&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50',
-          '[&:has([aria-selected].day-range-end)]:rounded-r-md',
-        ),
+        month_grid: 'w-full border-collapse',
+        weekdays: '',
+        weekday: 'text-muted-foreground font-normal text-[0.8rem] w-9 text-center',
+        week: '',
+        day: 'p-0 text-center text-sm',
         day_button: cn(
           buttonVariants({ variant: 'ghost' }),
           'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
@@ -44,8 +42,7 @@ function Calendar({ className, classNames, ...props }: CalendarProps) {
         selected:
           'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-md',
         today: 'bg-accent text-accent-foreground rounded-md',
-        outside:
-          'day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground',
+        outside: 'text-muted-foreground opacity-50',
         disabled: 'text-muted-foreground opacity-50',
         hidden: 'invisible',
         ...classNames,

--- a/apps/web/hooks/use-budget.ts
+++ b/apps/web/hooks/use-budget.ts
@@ -6,6 +6,7 @@ import {
   fetchTransactions,
   fetchCategories,
   fetchMonthlySummary,
+  fetchCategoryBreakdown,
   fetchBudgets,
   fetchBudgetAnalysis,
   createTransaction,
@@ -22,6 +23,7 @@ import {
   type UpdateTransactionDto,
   type CreateBudgetDto,
   type UpdateBudgetDto,
+  type CategoryBreakdownItem,
 } from '@/lib/api/budget';
 import type { PaginatedResponse } from '@my-wallet/shared';
 
@@ -209,6 +211,39 @@ export function useMonthlySummary(year: number, month: number): UseMonthlySummar
   const refetch = useCallback(() => setTick((t) => t + 1), []);
 
   return { summary, loading, error, refetch };
+}
+
+// ─── useCategoryBreakdown ─────────────────────────────────────────────────────
+
+interface UseCategoryBreakdownReturn {
+  breakdown: CategoryBreakdownItem[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useCategoryBreakdown(year: number, month: number): UseCategoryBreakdownReturn {
+  const [breakdown, setBreakdown] = useState<CategoryBreakdownItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchCategoryBreakdown(year, month)
+      .then((res) => {
+        if (!cancelled) setBreakdown(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '카테고리별 집계를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [year, month]);
+
+  return { breakdown, loading, error };
 }
 
 // ─── useBudgets ───────────────────────────────────────────────────────────────

--- a/apps/web/lib/api/budget.ts
+++ b/apps/web/lib/api/budget.ts
@@ -154,8 +154,18 @@ export function deleteCategory(id: string): Promise<void> {
 
 // ─── Summary API ──────────────────────────────────────────────────────────────
 
+export interface CategoryBreakdownItem {
+  categoryName: string;
+  type: string;
+  amount: number;
+}
+
 export function fetchMonthlySummary(year: number, month: number): Promise<MonthSummary> {
   return apiClient.get<MonthSummary>(`/transactions/summary/${year}/${month}`);
+}
+
+export function fetchCategoryBreakdown(year: number, month: number): Promise<CategoryBreakdownItem[]> {
+  return apiClient.get<CategoryBreakdownItem[]>(`/transactions/breakdown/${year}/${month}`);
 }
 
 // ─── Budget API ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**도넛차트 수정**
- `useBudgetAnalysis`(예산 설정 카테고리만) → `useCategoryBreakdown`(실제 거래 기반 집계)
- 새 API: `GET /transactions/breakdown/:year/:month`

**필터 개선**
- `input[type=date]` → Calendar Popover로 교체
- 날짜 선택 시 Popover 자동 닫힘
- 적용된 필터 칩 표시 + 개별/전체 초기화 버튼

**캘린더 정렬 수정**
- react-day-picker v9는 `<table>` 렌더링인데 flex classNames 적용으로 날짜 밀림 버그
- flex 제거, table 자체 레이아웃 사용으로 정상 정렬

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 풀 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)