### PR TITLE
fix(budget): apply-all 500 에러 + 예산분석 UI 개선

### DIFF
--- a/apps/api/src/budget/services/budget.service.ts
+++ b/apps/api/src/budget/services/budget.service.ts
@@ -157,11 +157,12 @@ export class BudgetService {
     let updated = 0;
     let skipped = 0;
 
-    await this.prisma.$transaction(async (tx) => {
-      for (const m of selectedMonths) {
-        const monthDate = new Date(
-          `${targetYear}-${String(m).padStart(2, '0')}-01`,
-        );
+    await this.prisma.$transaction(
+      async (tx) => {
+        for (const m of selectedMonths) {
+          const monthDate = new Date(
+            `${targetYear}-${String(m).padStart(2, '0')}-01`,
+          );
 
         for (const sourceBudget of sourceBudgets) {
           const existing = await tx.budget.findUnique({
@@ -197,7 +198,9 @@ export class BudgetService {
           }
         }
       }
-    });
+      },
+      { timeout: 30000 },
+    );
 
     return { created, updated, skipped };
   }

--- a/apps/web/app/(main)/budget/analysis/page.tsx
+++ b/apps/web/app/(main)/budget/analysis/page.tsx
@@ -21,6 +21,7 @@ import { BudgetProgress } from '@/components/budget/budget-progress';
 import { BudgetForm } from '@/components/budget/budget-form';
 import { ApplyAllDialog } from '@/components/budget/apply-all-dialog';
 import { useBudgets, useBudgetAnalysis, useCategories } from '@/hooks/use-budget';
+import { getCategoryColor } from '@/lib/category-colors';
 import type { Budget, CreateBudgetDto, UpdateBudgetDto } from '@/lib/api/budget';
 import type { TransactionType } from '@my-wallet/shared';
 import { BarChart3, Plus, Pencil, Trash2, Settings2, Copy } from 'lucide-react';
@@ -114,7 +115,11 @@ export default function BudgetAnalysisPage() {
         </CardHeader>
         <CardContent className="p-0">
           {budgetsLoading ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">불러오는 중...</div>
+            <div className="space-y-2 p-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+              ))}
+            </div>
           ) : budgets.length === 0 ? (
             <div className="py-8 text-center text-muted-foreground text-sm">
               설정된 예산이 없습니다. 예산을 추가해보세요.
@@ -133,7 +138,15 @@ export default function BudgetAnalysisPage() {
                 {budgets.map((budget) => (
                   <TableRow key={budget.id}>
                     <TableCell className="font-medium">
-                      {budget.category?.name ?? budget.categoryId}
+                      {(() => {
+                        const catName = budget.category?.name ?? '기타';
+                        const color = getCategoryColor(catName);
+                        return (
+                          <span className={`text-xs px-2 py-0.5 rounded-md ${color.bg} ${color.text}`}>
+                            {catName}
+                          </span>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell>
                       <Badge variant={TYPE_VARIANTS[budget.type]}>
@@ -185,9 +198,7 @@ export default function BudgetAnalysisPage() {
         </CardHeader>
         <CardContent>
           {analysisLoading ? (
-            <div className="h-48 flex items-center justify-center text-muted-foreground text-sm">
-              불러오는 중...
-            </div>
+            <div className="h-48 bg-muted animate-pulse rounded" />
           ) : (
             <BudgetChart data={analysis} />
           )}
@@ -201,7 +212,11 @@ export default function BudgetAnalysisPage() {
         </CardHeader>
         <CardContent className="p-0">
           {analysisLoading ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">불러오는 중...</div>
+            <div className="space-y-2 p-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+              ))}
+            </div>
           ) : analysis.length === 0 ? (
             <div className="py-8 text-center text-muted-foreground text-sm">
               분석할 데이터가 없습니다.

--- a/apps/web/components/budget/budget-form.tsx
+++ b/apps/web/components/budget/budget-form.tsx
@@ -55,7 +55,7 @@ export function BudgetForm({
     if (budget) {
       setType(budget.type);
       setCategoryId(budget.categoryId);
-      setAmount(String(budget.amount));
+      setAmount(budget.amount.toLocaleString('ko-KR'));
     } else {
       setType('EXPENSE');
       setCategoryId('');
@@ -163,11 +163,15 @@ export function BudgetForm({
           <div className="space-y-1.5">
             <label className="text-sm font-medium">예산 금액 (원)</label>
             <Input
-              type="number"
+              type="text"
+              inputMode="numeric"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => {
+                const raw = e.target.value.replace(/[^0-9]/g, '');
+                if (raw === '') { setAmount(''); return; }
+                setAmount(Number(raw).toLocaleString('ko-KR'));
+              }}
               placeholder="0"
-              min={1}
             />
           </div>
 


### PR DESCRIPTION
## Summary

- apply-all $transaction 타임아웃 5s → 30s (500 에러 해결)
- 예산 금액 입력 콤마 포맷
- 예산 테이블 카테고리 색상 뱃지
- 로딩 스켈레톤 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)