### PR TITLE
feat: 2-depth categories + budget analysis UX overhaul

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,52 @@
+# TODOS
+
+프로젝트 follow-up 관리. 스킬/컴포넌트별 그룹, priority 순서대로 정렬 (P0 → P4 → Completed).
+
+## Database / Migrations
+
+### P1: Rename migration drift 해소
+**Why:** `packages/database/prisma/migrations/20260409000000_rename_categories/migration.sql`가 `"Category"` (PascalCase 단수)를 참조하지만 init 마이그레이션은 `"categories"` (lowercase plural)를 생성. Prod DB 상태 불일치 가능성.
+**Context:** Ship 리뷰 (2026-04-21)에서 data-migration specialist가 CRITICAL 플래그. Rename 마이그레이션이 실제로 prod에서 성공했는지, 아니면 silent no-op으로 끝났는지 확인 필요. 현재 세션의 2-depth 마이그레이션은 이것과 독립 동작 (새 `categories_parent_id_idx` 등은 정상 생성 예정).
+**How to verify:** Render DB 접속 후 `\dt my_wallet.*` + `\d "categories"`로 실제 스키마 확인. 필요 시 `prisma migrate resolve --applied` 또는 수동 SQL 재적용.
+**Depends on:** prod DB 접근 권한
+
+### P3: NULLS NOT DISTINCT 전환 (PG 15+ 필요)
+**Why:** 현재 `@@unique([name, type, parentId])`는 `parentId=NULL` 로우를 distinct로 간주해 루트 카테고리 중복이 DB 레벨에서 차단되지 않음. App 레이어에서만 체크.
+**How:** PostgreSQL 버전이 15 이상이면 `UNIQUE INDEX ... NULLS NOT DISTINCT` 옵션 사용. 또는 partial unique index.
+**Context:** 1인 가계부 스케일에선 race 발생 확률 극히 낮음, 나중에 검토.
+
+## Backend / API
+
+### P2: Recommendations divisor 동적 계산
+**Why:** `budget-analysis.service.ts`의 `computeRecommendations`가 항상 3으로 나눔. 초기 사용자(1-2개월 이력만 보유)는 실제보다 낮게 추천받음.
+**How:** 실제 데이터가 존재하는 월 수를 카운트 (distinct YYYY-MM of priorTransactions)하여 divisor로 사용. 최소 1로 clamp.
+**Context:** Ship 리뷰 (2026-04-21)에서 maintainability specialist가 제안. 값 3은 RECOMMENDATION_LOOKBACK_MONTHS 상수.
+
+### P3: DRY 리팩터 — 카테고리 트리 정렬 로직
+**Why:** parent→children 순서 정렬 + 고아 승격 로직이 3곳에 중복:
+  - `apps/web/components/budget/budget-form.tsx:24` `orderCategoriesForDisplay`
+  - `apps/web/components/budget/transaction-form.tsx:84` inline IIFE
+  - `apps/web/components/budget/budget-analysis-tree.tsx:48` `buildTree`
+**How:** `apps/web/lib/categories.ts` 또는 `packages/shared/src/utils/category-tree.ts`에 통합.
+**Context:** Ship 리뷰 (2026-04-21)에서 maintainability specialist가 confidence 9로 플래그.
+
+## Frontend / Web
+
+### P2: Web 테스트 인프라 (Vitest + RTL)
+**Why:** 현재 `apps/web/`에 테스트 파일 0개. `budget-analysis-tree.tsx`, `category-editor-dialog.tsx`, 정렬 로직, flatMap 트리 렌더링 등이 manual QA에만 의존.
+**How:** Vitest + @testing-library/react 도입. `apps/web/package.json`에 `test` 스크립트 + `vitest.config.ts`. 최소 5개 핵심 컴포넌트 스모크 테스트로 시작.
+**Context:** 초기 설계 doc부터 NOT in scope으로 명시. 이번 ship에서 명시적으로 follow-up 전환.
+
+### P3: 에디터 다이얼로그 prop wiring 정리
+**Why:** `apps/web/app/(main)/settings/categories/page.tsx:249-272`에 중첩 삼항 9개. `deriveDialogProps(dialog, activeTab, tree)` 유틸로 추출 권장.
+**Context:** Ship 리뷰 (2026-04-21), maintainability specialist 제안.
+
+## Design / UX
+
+### P3: Tooltip 문구 shared constant
+**Why:** "부모 예산은 하위 카테고리 합계의 상한 캡..." 문구가 `budget-analysis-tree.tsx:196`와 `analysis/page.tsx:213` 두 곳에 하드코딩.
+**How:** 추후 i18n 도입 시 함께 처리. 단기적으론 `apps/web/lib/copy.ts`에 상수화.
+
+## Completed
+
+_(Ship 이후 완료 항목이 여기 기록됨)_

--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,0 +1,33 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+        Buffer: 'readonly',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/no-empty-object-type': 'off',
+      // Nest test guards use { canActivate: Function } pattern — too entrenched to refactor now
+      '@typescript-eslint/no-unsafe-function-type': 'warn',
+    },
+  },
+);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "build": "nest build",
     "start": "nest start",
     "start:prod": "node dist/apps/api/src/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "jest",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
@@ -30,6 +30,7 @@
     "rxjs": "^7.8.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
@@ -37,9 +38,11 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.0",
     "@types/passport-jwt": "^4.0.0",
+    "eslint": "^9.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/api/src/budget/controllers/category.controller.spec.ts
+++ b/apps/api/src/budget/controllers/category.controller.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { CategoryController } from './category.controller';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+type CategoryRow = {
+  id: string;
+  name: string;
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+  parentId: string | null;
+  sortOrder: number;
+  isActive: boolean;
+};
+
+function makeCategory(overrides: Partial<CategoryRow> = {}): CategoryRow {
+  return {
+    id: 'cat-1',
+    name: '식비',
+    type: 'EXPENSE',
+    parentId: null,
+    sortOrder: 0,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+const mockPrisma = {
+  category: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+  },
+};
+
+describe('CategoryController', () => {
+  let controller: CategoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [{ provide: PrismaService, useValue: mockPrisma }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<CategoryController>(CategoryController);
+    jest.clearAllMocks();
+  });
+
+  // ─── findTree ──────────────────────────────────────────────────────────
+
+  describe('findTree', () => {
+    it('루트와 자식을 2-depth 트리로 조립한다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([
+        makeCategory({ id: 'p1', name: '주거', parentId: null, sortOrder: 1 }),
+        makeCategory({ id: 'c1', name: '월세', parentId: 'p1', sortOrder: 1 }),
+        makeCategory({ id: 'c2', name: '관리비', parentId: 'p1', sortOrder: 2 }),
+        makeCategory({ id: 'p2', name: '식비', parentId: null, sortOrder: 2 }),
+      ]);
+
+      const result = await controller.findTree('EXPENSE');
+
+      expect(result).toHaveLength(2);
+      const [first, second] = result;
+      expect(first.name).toBe('주거');
+      expect(first.children).toHaveLength(2);
+      expect(first.children[0].name).toBe('월세');
+      expect(first.children[1].name).toBe('관리비');
+      expect(second.name).toBe('식비');
+      expect(second.children).toHaveLength(0);
+    });
+
+    it('부모가 결과에 없는 자식은 루트로 승격된다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([
+        makeCategory({ id: 'c1', name: '월세', parentId: 'missing' }),
+      ]);
+
+      const result = await controller.findTree('EXPENSE');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('c1');
+    });
+
+    it('sortOrder 기준 오름차순 정렬된다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([
+        makeCategory({ id: 'a', name: 'A', sortOrder: 5 }),
+        makeCategory({ id: 'b', name: 'B', sortOrder: 1 }),
+      ]);
+
+      const result = await controller.findTree('EXPENSE');
+
+      expect(result.map((r) => r.id)).toEqual(['b', 'a']);
+    });
+  });
+
+  // ─── create ────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('루트 카테고리를 생성한다', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.category.create.mockResolvedValue(
+        makeCategory({ id: 'new', name: '식비' }),
+      );
+
+      await controller.create({
+        name: '식비',
+        type: 'EXPENSE',
+      });
+
+      expect(mockPrisma.category.create).toHaveBeenCalledWith({
+        data: {
+          name: '식비',
+          type: 'EXPENSE',
+          parentId: null,
+          sortOrder: 0,
+        },
+      });
+    });
+
+    it('자식 카테고리를 생성한다', async () => {
+      const parent = makeCategory({ id: 'p1', name: '주거' });
+      mockPrisma.category.findUnique.mockResolvedValue(parent);
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.category.create.mockResolvedValue(
+        makeCategory({ id: 'c1', name: '월세', parentId: 'p1' }),
+      );
+
+      await controller.create({
+        name: '월세',
+        type: 'EXPENSE',
+        parentId: 'p1',
+      });
+
+      expect(mockPrisma.category.create).toHaveBeenCalledWith({
+        data: {
+          name: '월세',
+          type: 'EXPENSE',
+          parentId: 'p1',
+          sortOrder: 0,
+        },
+      });
+    });
+
+    it('존재하지 않는 부모는 400을 던진다', async () => {
+      mockPrisma.category.findUnique.mockResolvedValue(null);
+
+      await expect(
+        controller.create({ name: '월세', type: 'EXPENSE', parentId: 'missing' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('2-depth 초과 시 400 (부모 자신이 자식인 경우)', async () => {
+      const parent = makeCategory({ id: 'p1', name: '월세', parentId: 'grandparent' });
+      mockPrisma.category.findUnique.mockResolvedValue(parent);
+
+      await expect(
+        controller.create({ name: '세부', type: 'EXPENSE', parentId: 'p1' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('부모와 타입이 다르면 400', async () => {
+      const parent = makeCategory({ id: 'p1', name: '주거', type: 'EXPENSE' });
+      mockPrisma.category.findUnique.mockResolvedValue(parent);
+
+      await expect(
+        controller.create({ name: '월세', type: 'SAVING', parentId: 'p1' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('비활성 부모 밑에는 추가 불가 400', async () => {
+      const parent = makeCategory({ id: 'p1', name: '주거', isActive: false });
+      mockPrisma.category.findUnique.mockResolvedValue(parent);
+
+      await expect(
+        controller.create({ name: '월세', type: 'EXPENSE', parentId: 'p1' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('같은 위치에 중복 이름은 409', async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(
+        makeCategory({ id: 'existing', name: '식비' }),
+      );
+
+      await expect(
+        controller.create({ name: '식비', type: 'EXPENSE' }),
+      ).rejects.toMatchObject({ status: HttpStatus.CONFLICT });
+    });
+
+    it('비활성 카테고리와 이름 충돌 시 재활성화한다', async () => {
+      const existing = makeCategory({ id: 'x1', name: '식비', isActive: false });
+      mockPrisma.category.findFirst.mockResolvedValue(existing);
+      mockPrisma.category.update.mockResolvedValue({
+        ...existing,
+        isActive: true,
+      });
+
+      const result = await controller.create({ name: '식비', type: 'EXPENSE' });
+
+      expect(mockPrisma.category.update).toHaveBeenCalledWith({
+        where: { id: 'x1' },
+        data: { isActive: true, sortOrder: 0 },
+      });
+      expect(result.isActive).toBe(true);
+    });
+
+    it('REGRESSION: 다른 부모 아래 동일 이름은 허용된다', async () => {
+      const parent = makeCategory({ id: 'p2', name: '저축' });
+      mockPrisma.category.findUnique.mockResolvedValue(parent);
+      // 다른 parent 하에서는 중복이 아님
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.category.create.mockResolvedValue(
+        makeCategory({ id: 'c1', name: '기타', parentId: 'p2' }),
+      );
+
+      await controller.create({ name: '기타', type: 'EXPENSE', parentId: 'p2' });
+
+      expect(mockPrisma.category.create).toHaveBeenCalled();
+    });
+  });
+
+  // ─── update ────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('parent를 변경하여 reparent 한다', async () => {
+      const leaf = { ...makeCategory({ id: 'c1', name: '월세', parentId: 'p1' }), children: [] };
+      const newParent = makeCategory({ id: 'p2', name: '고정비' });
+      mockPrisma.category.findUnique
+        .mockResolvedValueOnce(leaf)       // 대상 leaf
+        .mockResolvedValueOnce(newParent); // 새 부모
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.category.update.mockResolvedValue({ ...leaf, parentId: 'p2' });
+
+      await controller.update('c1', { parentId: 'p2' });
+
+      expect(mockPrisma.category.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { parentId: 'p2' },
+      });
+    });
+
+    it('자기 자신을 parent로 지정하면 400', async () => {
+      const cat = { ...makeCategory({ id: 'self' }), children: [] };
+      mockPrisma.category.findUnique
+        .mockResolvedValueOnce(cat)
+        .mockResolvedValueOnce(cat); // same
+
+      await expect(
+        controller.update('self', { parentId: 'self' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('자식 있는 대분류를 소분류로 변경 불가 400', async () => {
+      const parentWithChildren = {
+        ...makeCategory({ id: 'p1', name: '주거' }),
+        children: [makeCategory({ id: 'c1', parentId: 'p1' })],
+      };
+      mockPrisma.category.findUnique.mockResolvedValueOnce(parentWithChildren);
+
+      await expect(
+        controller.update('p1', { parentId: 'other-parent' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('2-depth 초과 reparent 시도 400', async () => {
+      const leaf = { ...makeCategory({ id: 'c1', parentId: 'p1' }), children: [] };
+      const deepParent = makeCategory({ id: 'c-other', parentId: 'p2' });
+      mockPrisma.category.findUnique
+        .mockResolvedValueOnce(leaf)
+        .mockResolvedValueOnce(deepParent);
+
+      await expect(
+        controller.update('c1', { parentId: 'c-other' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('parent 타입이 다르면 reparent 400', async () => {
+      const leaf = { ...makeCategory({ id: 'c1', type: 'EXPENSE', parentId: 'p1' }), children: [] };
+      const otherTypeParent = makeCategory({ id: 'p-saving', type: 'SAVING' });
+      mockPrisma.category.findUnique
+        .mockResolvedValueOnce(leaf)
+        .mockResolvedValueOnce(otherTypeParent);
+
+      await expect(
+        controller.update('c1', { parentId: 'p-saving' }),
+      ).rejects.toMatchObject({ status: HttpStatus.BAD_REQUEST });
+    });
+
+    it('이름 변경 시 중복 검사한다', async () => {
+      const cat = { ...makeCategory({ id: 'c1', name: '식비' }), children: [] };
+      const duplicate = makeCategory({ id: 'other', name: '새이름' });
+      mockPrisma.category.findUnique.mockResolvedValueOnce(cat);
+      mockPrisma.category.findFirst.mockResolvedValue(duplicate);
+
+      await expect(
+        controller.update('c1', { name: '새이름' }),
+      ).rejects.toMatchObject({ status: HttpStatus.CONFLICT });
+    });
+
+    it('없는 카테고리 수정은 404', async () => {
+      mockPrisma.category.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        controller.update('missing', { name: 'x' }),
+      ).rejects.toMatchObject({ status: HttpStatus.NOT_FOUND });
+    });
+  });
+
+  // ─── remove ────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('자식 있는 대분류는 409를 던진다', async () => {
+      mockPrisma.category.findUnique.mockResolvedValue({
+        ...makeCategory({ id: 'p1' }),
+        _count: { transactions: 0, budgets: 0, children: 2 },
+      });
+      mockPrisma.category.count.mockResolvedValue(2);
+
+      await expect(controller.remove('p1')).rejects.toMatchObject({
+        status: HttpStatus.CONFLICT,
+      });
+    });
+
+    it('거래/예산 연결된 카테고리는 soft delete (isActive=false)', async () => {
+      mockPrisma.category.findUnique.mockResolvedValue({
+        ...makeCategory({ id: 'c1' }),
+        _count: { transactions: 5, budgets: 1, children: 0 },
+      });
+      mockPrisma.category.count.mockResolvedValue(0);
+      mockPrisma.category.update.mockResolvedValue(
+        makeCategory({ id: 'c1', isActive: false }),
+      );
+
+      await controller.remove('c1');
+
+      expect(mockPrisma.category.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { isActive: false },
+      });
+      expect(mockPrisma.category.delete).not.toHaveBeenCalled();
+    });
+
+    it('연결 없으면 hard delete', async () => {
+      mockPrisma.category.findUnique.mockResolvedValue({
+        ...makeCategory({ id: 'c1' }),
+        _count: { transactions: 0, budgets: 0, children: 0 },
+      });
+      mockPrisma.category.count.mockResolvedValue(0);
+      mockPrisma.category.delete.mockResolvedValue(makeCategory({ id: 'c1' }));
+
+      await controller.remove('c1');
+
+      expect(mockPrisma.category.delete).toHaveBeenCalledWith({ where: { id: 'c1' } });
+      expect(mockPrisma.category.update).not.toHaveBeenCalled();
+    });
+
+    it('없는 카테고리는 404', async () => {
+      mockPrisma.category.findUnique.mockResolvedValue(null);
+
+      await expect(controller.remove('missing')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+  });
+});

--- a/apps/api/src/budget/controllers/category.controller.ts
+++ b/apps/api/src/budget/controllers/category.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   UseGuards,
   HttpException,
   HttpStatus,
@@ -15,6 +16,7 @@ import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCategoryDto } from '../dto/create-category.dto';
 import { UpdateCategoryDto } from '../dto/update-category.dto';
+import type { TransactionType, CategoryNode } from '@my-wallet/shared';
 
 @ApiTags('Categories')
 @ApiBearerAuth()
@@ -23,13 +25,61 @@ import { UpdateCategoryDto } from '../dto/update-category.dto';
 export class CategoryController {
   constructor(private readonly prisma: PrismaService) {}
 
+  // ─── Read ───────────────────────────────────────────────────────────────
+
   @Get()
-  @ApiOperation({ summary: '전체 카테고리 목록 조회' })
+  @ApiOperation({ summary: '전체 카테고리 목록 조회 (flat)' })
   findAll() {
     return this.prisma.category.findMany({
       where: { isActive: true },
-      orderBy: [{ type: 'asc' }, { sortOrder: 'asc' }],
+      orderBy: [{ type: 'asc' }, { parentId: 'asc' }, { sortOrder: 'asc' }],
     });
+  }
+
+  @Get('tree')
+  @ApiOperation({ summary: '카테고리 트리 조회 (2-depth)' })
+  async findTree(@Query('type') type?: TransactionType): Promise<CategoryNode[]> {
+    const where: { isActive: boolean; type?: TransactionType } = { isActive: true };
+    if (type) where.type = type;
+
+    const categories = await this.prisma.category.findMany({
+      where,
+      orderBy: [{ sortOrder: 'asc' }],
+    });
+
+    const byId = new Map<string, CategoryNode>();
+    for (const cat of categories) {
+      byId.set(cat.id, {
+        id: cat.id,
+        name: cat.name,
+        type: cat.type as TransactionType,
+        parentId: cat.parentId,
+        sortOrder: cat.sortOrder,
+        isActive: cat.isActive,
+        children: [],
+      });
+    }
+
+    const roots: CategoryNode[] = [];
+    for (const node of byId.values()) {
+      if (node.parentId) {
+        const parent = byId.get(node.parentId);
+        if (parent) {
+          parent.children.push(node);
+        } else {
+          // 부모가 비활성/필터됨 → 루트로 승격
+          roots.push(node);
+        }
+      } else {
+        roots.push(node);
+      }
+    }
+
+    const sortByOrder = (a: CategoryNode, b: CategoryNode) => a.sortOrder - b.sortOrder;
+    roots.sort(sortByOrder);
+    for (const root of roots) root.children.sort(sortByOrder);
+
+    return roots;
   }
 
   @Get('expense')
@@ -37,7 +87,7 @@ export class CategoryController {
   findExpense() {
     return this.prisma.category.findMany({
       where: { isActive: true, type: 'EXPENSE' },
-      orderBy: { sortOrder: 'asc' },
+      orderBy: [{ parentId: 'asc' }, { sortOrder: 'asc' }],
     });
   }
 
@@ -46,7 +96,7 @@ export class CategoryController {
   findIncome() {
     return this.prisma.category.findMany({
       where: { isActive: true, type: 'INCOME' },
-      orderBy: { sortOrder: 'asc' },
+      orderBy: [{ parentId: 'asc' }, { sortOrder: 'asc' }],
     });
   }
 
@@ -55,81 +105,192 @@ export class CategoryController {
   findSaving() {
     return this.prisma.category.findMany({
       where: { isActive: true, type: 'SAVING' },
-      orderBy: { sortOrder: 'asc' },
+      orderBy: [{ parentId: 'asc' }, { sortOrder: 'asc' }],
     });
   }
+
+  // ─── Create ─────────────────────────────────────────────────────────────
 
   @Post()
   @ApiOperation({ summary: '카테고리 생성' })
   async create(@Body() dto: CreateCategoryDto) {
-    const existing = await this.prisma.category.findUnique({
-      where: { name_type: { name: dto.name, type: dto.type } },
-    });
+    const parentId = dto.parentId ?? null;
+
+    // 1. parent 유효성 검증
+    if (parentId) {
+      const parent = await this.prisma.category.findUnique({
+        where: { id: parentId },
+      });
+      if (!parent) {
+        throw new HttpException('상위 카테고리를 찾을 수 없습니다.', HttpStatus.BAD_REQUEST);
+      }
+      if (parent.parentId !== null) {
+        throw new HttpException(
+          '카테고리 계층은 최대 2단계(대분류 > 소분류)까지만 허용됩니다.',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      if (parent.type !== dto.type) {
+        throw new HttpException(
+          '상위 카테고리와 동일한 유형이어야 합니다.',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      if (!parent.isActive) {
+        throw new HttpException(
+          '비활성 상위 카테고리 아래에는 소분류를 추가할 수 없습니다.',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // 2. 중복 검사 (name, type, parentId) — NULL parent도 고려
+    const existing = await this.findByNameTypeParent(dto.name, dto.type, parentId);
     if (existing) {
       if (!existing.isActive) {
-        // 비활성 카테고리 재활성화
         return this.prisma.category.update({
           where: { id: existing.id },
-          data: { isActive: true, sortOrder: dto.sortOrder ?? existing.sortOrder },
+          data: {
+            isActive: true,
+            sortOrder: dto.sortOrder ?? existing.sortOrder,
+          },
         });
       }
       throw new HttpException(
-        '같은 유형에 동일한 이름의 카테고리가 이미 존재합니다.',
+        '같은 위치에 동일한 이름의 카테고리가 이미 존재합니다.',
         HttpStatus.CONFLICT,
       );
     }
+
     return this.prisma.category.create({
       data: {
         name: dto.name,
         type: dto.type,
+        parentId,
         sortOrder: dto.sortOrder ?? 0,
       },
     });
   }
 
+  // ─── Update ─────────────────────────────────────────────────────────────
+
   @Put(':id')
   @ApiOperation({ summary: '카테고리 수정' })
   async update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
-    const category = await this.prisma.category.findUnique({ where: { id } });
+    const category = await this.prisma.category.findUnique({
+      where: { id },
+      include: { children: true },
+    });
     if (!category) {
       throw new HttpException('카테고리를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
     }
-    // 이름 변경 시 중복 체크
-    if (dto.name && dto.name !== category.name) {
-      const duplicate = await this.prisma.category.findUnique({
-        where: { name_type: { name: dto.name, type: category.type } },
-      });
+
+    const nextName = dto.name ?? category.name;
+    const nextParentId =
+      dto.parentId === undefined ? category.parentId : dto.parentId ?? null;
+
+    // parentId 변경 시 검증
+    if (dto.parentId !== undefined && dto.parentId !== category.parentId) {
+      if (nextParentId !== null) {
+        // 자식이 있는 카테고리는 소분류로 변경 불가 (2-depth 유지)
+        if (category.children.length > 0) {
+          throw new HttpException(
+            '하위 카테고리가 있는 대분류는 소분류로 변경할 수 없습니다.',
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+        const parent = await this.prisma.category.findUnique({
+          where: { id: nextParentId },
+        });
+        if (!parent) {
+          throw new HttpException('상위 카테고리를 찾을 수 없습니다.', HttpStatus.BAD_REQUEST);
+        }
+        if (parent.parentId !== null) {
+          throw new HttpException(
+            '카테고리 계층은 최대 2단계까지만 허용됩니다.',
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+        if (parent.type !== category.type) {
+          throw new HttpException(
+            '상위 카테고리와 동일한 유형이어야 합니다.',
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+        if (parent.id === category.id) {
+          throw new HttpException('자기 자신을 상위로 지정할 수 없습니다.', HttpStatus.BAD_REQUEST);
+        }
+      }
+    }
+
+    // 이름 또는 parentId 변경 시 중복 체크
+    if (nextName !== category.name || nextParentId !== category.parentId) {
+      const duplicate = await this.findByNameTypeParent(
+        nextName,
+        category.type as TransactionType,
+        nextParentId,
+      );
       if (duplicate && duplicate.id !== id) {
         throw new HttpException(
-          '같은 유형에 동일한 이름의 카테고리가 이미 존재합니다.',
+          '같은 위치에 동일한 이름의 카테고리가 이미 존재합니다.',
           HttpStatus.CONFLICT,
         );
       }
     }
+
     return this.prisma.category.update({
       where: { id },
-      data: dto,
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.parentId !== undefined && { parentId: nextParentId }),
+        ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+      },
     });
   }
+
+  // ─── Delete ─────────────────────────────────────────────────────────────
 
   @Delete(':id')
   @ApiOperation({ summary: '카테고리 삭제 (비활성화)' })
   async remove(@Param('id') id: string) {
     const category = await this.prisma.category.findUnique({
       where: { id },
-      include: { _count: { select: { transactions: true, budgets: true } } },
+      include: {
+        _count: { select: { transactions: true, budgets: true, children: true } },
+      },
     });
     if (!category) {
       throw new HttpException('카테고리를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
     }
-    // 연결된 거래/예산이 있으면 soft delete
+    // 활성 자식이 있으면 삭제 차단
+    const activeChildrenCount = await this.prisma.category.count({
+      where: { parentId: id, isActive: true },
+    });
+    if (activeChildrenCount > 0) {
+      throw new HttpException(
+        '하위 카테고리가 있는 대분류는 삭제할 수 없습니다. 하위를 먼저 정리해주세요.',
+        HttpStatus.CONFLICT,
+      );
+    }
     if (category._count.transactions > 0 || category._count.budgets > 0) {
       return this.prisma.category.update({
         where: { id },
         data: { isActive: false },
       });
     }
-    // 연결된 데이터 없으면 하드 삭제
     return this.prisma.category.delete({ where: { id } });
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────────
+
+  private async findByNameTypeParent(
+    name: string,
+    type: TransactionType,
+    parentId: string | null,
+  ) {
+    return this.prisma.category.findFirst({
+      where: { name, type, parentId },
+    });
   }
 }

--- a/apps/api/src/budget/dto/create-category.dto.ts
+++ b/apps/api/src/budget/dto/create-category.dto.ts
@@ -13,6 +13,11 @@ export class CreateCategoryDto {
   })
   type: 'INCOME' | 'EXPENSE' | 'SAVING';
 
+  @ApiPropertyOptional({ description: '상위 카테고리 ID (대분류일 경우 null)' })
+  @IsOptional()
+  @IsString()
+  parentId?: string | null;
+
   @ApiPropertyOptional({ description: '정렬 순서', default: 0 })
   @IsOptional()
   @IsInt()

--- a/apps/api/src/budget/dto/update-category.dto.ts
+++ b/apps/api/src/budget/dto/update-category.dto.ts
@@ -7,6 +7,11 @@ export class UpdateCategoryDto {
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: '상위 카테고리 ID (null로 설정 시 대분류로 변경)' })
+  @IsOptional()
+  @IsString()
+  parentId?: string | null;
+
   @ApiPropertyOptional({ description: '정렬 순서' })
   @IsOptional()
   @IsInt()

--- a/apps/api/src/budget/services/budget-analysis.service.spec.ts
+++ b/apps/api/src/budget/services/budget-analysis.service.spec.ts
@@ -3,9 +3,31 @@ import { BudgetAnalysisService } from './budget-analysis.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
 const mockPrisma = {
+  category: { findMany: jest.fn() },
   budget: { findMany: jest.fn() },
   transaction: { findMany: jest.fn() },
 };
+
+type CategoryRow = {
+  id: string;
+  name: string;
+  type: 'INCOME' | 'EXPENSE' | 'SAVING';
+  parentId: string | null;
+  sortOrder: number;
+  isActive: boolean;
+};
+
+function makeCategory(overrides: Partial<CategoryRow> = {}): CategoryRow {
+  return {
+    id: 'cat-1',
+    name: '식비',
+    type: 'EXPENSE',
+    parentId: null,
+    sortOrder: 0,
+    isActive: true,
+    ...overrides,
+  };
+}
 
 function makeBudget(
   overrides: Partial<{
@@ -47,6 +69,8 @@ describe('BudgetAnalysisService', () => {
 
     service = module.get<BudgetAnalysisService>(BudgetAnalysisService);
     jest.clearAllMocks();
+    // 기본: 추천용 직전 거래도 빈 배열로 (별도 설정하지 않을 때)
+    mockPrisma.transaction.findMany.mockResolvedValue([]);
   });
 
   describe('analyze', () => {
@@ -54,30 +78,48 @@ describe('BudgetAnalysisService', () => {
     const year = 2026;
     const month = 3;
 
-    it('예산이 없으면 빈 배열을 반환한다', async () => {
+    it('활성 카테고리가 없으면 빈 배열을 반환한다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([]);
       mockPrisma.budget.findMany.mockResolvedValue([]);
 
       const result = await service.analyze(userId, year, month);
 
       expect(result).toEqual([]);
-      expect(mockPrisma.transaction.findMany).not.toHaveBeenCalled();
     });
 
-    it('예산은 있지만 거래가 없으면 actual이 0이다', async () => {
+    it('예산이 없는 카테고리도 UNSET 상태로 포함된다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([makeCategory()]);
+      mockPrisma.budget.findMany.mockResolvedValue([]);
+
+      const result = await service.analyze(userId, year, month);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('UNSET');
+      expect(result[0].isBudgeted).toBe(false);
+      expect(result[0].budget).toBe(0);
+    });
+
+    it('예산은 있지만 거래가 없으면 actual이 0이고 status가 GOOD이다', async () => {
+      mockPrisma.category.findMany.mockResolvedValue([makeCategory()]);
       mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-      mockPrisma.transaction.findMany.mockResolvedValue([]);
 
       const result = await service.analyze(userId, year, month);
 
       expect(result).toHaveLength(1);
       expect(result[0].actual).toBe(0);
       expect(result[0].difference).toBe(100000);
+      expect(result[0].status).toBe('GOOD');
+      expect(result[0].isBudgeted).toBe(true);
     });
 
     it('올바른 필드 구조를 반환한다', async () => {
-      const budget = makeBudget({ categoryId: 'cat-1', categoryName: '식비', amount: 100000 });
-      mockPrisma.budget.findMany.mockResolvedValue([budget]);
-      mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 80000)]);
+      mockPrisma.category.findMany.mockResolvedValue([makeCategory({ id: 'cat-1', name: '식비' })]);
+      mockPrisma.budget.findMany.mockResolvedValue([
+        makeBudget({ categoryId: 'cat-1', categoryName: '식비', amount: 100000 }),
+      ]);
+      mockPrisma.transaction.findMany
+        .mockResolvedValueOnce([makeTx('cat-1', 80000)]) // 이번 달
+        .mockResolvedValueOnce([]); // 추천용 직전 거래
 
       const result = await service.analyze(userId, year, month);
 
@@ -85,6 +127,9 @@ describe('BudgetAnalysisService', () => {
         categoryId: 'cat-1',
         categoryName: '식비',
         type: 'EXPENSE',
+        parentId: null,
+        isParent: false,
+        isBudgeted: true,
         budget: 100000,
         actual: 80000,
         difference: 20000,
@@ -92,9 +137,15 @@ describe('BudgetAnalysisService', () => {
     });
 
     describe('EXPENSE 상태 경계값', () => {
+      beforeEach(() => {
+        mockPrisma.category.findMany.mockResolvedValue([makeCategory()]);
+      });
+
       it('달성률 80% 미만(79%)이면 GOOD이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 79000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 79000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -103,7 +154,9 @@ describe('BudgetAnalysisService', () => {
 
       it('달성률이 정확히 80%이면 WARNING이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 80000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 80000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -112,7 +165,9 @@ describe('BudgetAnalysisService', () => {
 
       it('달성률이 정확히 100%이면 WARNING이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 100000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 100000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -121,7 +176,9 @@ describe('BudgetAnalysisService', () => {
 
       it('달성률이 100% 초과(101%)이면 OVER이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 101000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 101000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -130,9 +187,17 @@ describe('BudgetAnalysisService', () => {
     });
 
     describe('INCOME 상태 경계값', () => {
+      beforeEach(() => {
+        mockPrisma.category.findMany.mockResolvedValue([
+          makeCategory({ id: 'cat-1', name: '급여', type: 'INCOME' }),
+        ]);
+      });
+
       it('달성률이 정확히 100% 이상이면 GOOD이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ type: 'INCOME', amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 100000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 100000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -141,7 +206,9 @@ describe('BudgetAnalysisService', () => {
 
       it('달성률이 정확히 80%이면 WARNING이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ type: 'INCOME', amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 80000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 80000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -150,7 +217,9 @@ describe('BudgetAnalysisService', () => {
 
       it('달성률이 80% 미만(79%)이면 OVER이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ type: 'INCOME', amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 79000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 79000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -159,10 +228,15 @@ describe('BudgetAnalysisService', () => {
     });
 
     describe('achievementRate', () => {
+      beforeEach(() => {
+        mockPrisma.category.findMany.mockResolvedValue([makeCategory()]);
+      });
+
       it('소수점 2자리로 반올림한다', async () => {
-        // 1/3 ≈ 33.33%
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 3 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 1)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 1)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -180,7 +254,9 @@ describe('BudgetAnalysisService', () => {
 
       it('예산이 0이고 실제가 있으면 achievementRate는 100이다', async () => {
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 0 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([makeTx('cat-1', 5000)]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([makeTx('cat-1', 5000)])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
@@ -190,17 +266,22 @@ describe('BudgetAnalysisService', () => {
 
     describe('복합 카테고리', () => {
       it('EXPENSE와 INCOME이 혼재할 때 각각 올바른 상태를 반환한다', async () => {
+        mockPrisma.category.findMany.mockResolvedValue([
+          makeCategory({ id: 'cat-1', name: '식비', type: 'EXPENSE' }),
+          makeCategory({ id: 'cat-2', name: '월급', type: 'INCOME' }),
+        ]);
         const budgets = [
           makeBudget({ id: 'b1', categoryId: 'cat-1', categoryName: '식비', type: 'EXPENSE', amount: 100000 }),
           makeBudget({ id: 'b2', categoryId: 'cat-2', categoryName: '월급', type: 'INCOME', amount: 200000 }),
         ];
-        budgets[1].category = { id: 'cat-2', name: '월급' };
 
         mockPrisma.budget.findMany.mockResolvedValue(budgets);
-        mockPrisma.transaction.findMany.mockResolvedValue([
-          makeTx('cat-1', 50000),   // EXPENSE: 50% → GOOD
-          makeTx('cat-2', 200000),  // INCOME: 100% → GOOD
-        ]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([
+            makeTx('cat-1', 50000),   // EXPENSE 50% → GOOD
+            makeTx('cat-2', 200000),  // INCOME 100% → GOOD
+          ])
+          .mockResolvedValueOnce([]);
 
         const result = await service.analyze(userId, year, month);
 
@@ -212,17 +293,49 @@ describe('BudgetAnalysisService', () => {
       });
 
       it('카테고리별 거래 합산이 올바르게 계산된다', async () => {
+        mockPrisma.category.findMany.mockResolvedValue([makeCategory({ id: 'cat-1' })]);
         mockPrisma.budget.findMany.mockResolvedValue([makeBudget({ amount: 100000 })]);
-        mockPrisma.transaction.findMany.mockResolvedValue([
-          makeTx('cat-1', 30000),
-          makeTx('cat-1', 50000),
-          makeTx('cat-other', 99999), // 다른 카테고리는 합산 제외
-        ]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([
+            makeTx('cat-1', 30000),
+            makeTx('cat-1', 50000),
+            makeTx('cat-other', 99999), // 활성 카테고리가 아니므로 결과에 없음
+          ])
+          .mockResolvedValueOnce([]);
 
         const [item] = await service.analyze(userId, year, month);
 
         expect(item.actual).toBe(80000);
         expect(item.status).toBe('WARNING');
+      });
+    });
+
+    describe('부모/자식 rollup', () => {
+      it('부모 카테고리 actual은 자식 leaf actual 합으로 계산된다', async () => {
+        mockPrisma.category.findMany.mockResolvedValue([
+          makeCategory({ id: 'parent-1', name: '주거', parentId: null }),
+          makeCategory({ id: 'leaf-1', name: '월세', parentId: 'parent-1' }),
+          makeCategory({ id: 'leaf-2', name: '관리비', parentId: 'parent-1' }),
+        ]);
+        mockPrisma.budget.findMany.mockResolvedValue([]);
+        mockPrisma.transaction.findMany
+          .mockResolvedValueOnce([
+            makeTx('leaf-1', 400000),
+            makeTx('leaf-2', 80000),
+          ])
+          .mockResolvedValueOnce([]);
+
+        const result = await service.analyze(userId, year, month);
+
+        const parent = result.find((r) => r.categoryId === 'parent-1')!;
+        const leaf1 = result.find((r) => r.categoryId === 'leaf-1')!;
+        const leaf2 = result.find((r) => r.categoryId === 'leaf-2')!;
+
+        expect(parent.actual).toBe(480000);
+        expect(parent.isParent).toBe(true);
+        expect(leaf1.actual).toBe(400000);
+        expect(leaf1.parentId).toBe('parent-1');
+        expect(leaf2.actual).toBe(80000);
       });
     });
   });

--- a/apps/api/src/budget/services/budget-analysis.service.ts
+++ b/apps/api/src/budget/services/budget-analysis.service.ts
@@ -1,9 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import type { BudgetStatus, BudgetAnalysisItem } from '@my-wallet/shared';
+import type {
+  BudgetStatus,
+  BudgetAnalysisItem,
+  TransactionType,
+} from '@my-wallet/shared';
 
 const WARNING_THRESHOLD = 0.8;
 const ACHIEVEMENT_100 = 1.0;
+const RECOMMENDATION_LOOKBACK_MONTHS = 3;
+
+type CategoryLite = {
+  id: string;
+  name: string;
+  type: TransactionType;
+  parentId: string | null;
+  sortOrder: number;
+};
 
 @Injectable()
 export class BudgetAnalysisService {
@@ -17,77 +30,172 @@ export class BudgetAnalysisService {
     const monthStr = `${year}-${String(month).padStart(2, '0')}`;
     const monthDate = new Date(`${monthStr}-01`);
     const startDate = new Date(`${monthStr}-01`);
-    // Last day of month: first day of next month minus 1 day
     const nextMonthDate = new Date(monthDate);
     nextMonthDate.setUTCMonth(nextMonthDate.getUTCMonth() + 1);
     nextMonthDate.setUTCDate(nextMonthDate.getUTCDate() - 1);
     const endDate = nextMonthDate;
 
-    const budgets = await this.prisma.budget.findMany({
-      where: { userId, month: monthDate },
-      include: { category: true },
-    });
+    const [categoriesRaw, budgets, transactions] = await Promise.all([
+      this.prisma.category.findMany({
+        where: { isActive: true },
+        orderBy: [{ type: 'asc' }, { parentId: 'asc' }, { sortOrder: 'asc' }],
+      }),
+      this.prisma.budget.findMany({
+        where: { userId, month: monthDate },
+        include: { category: true },
+      }),
+      this.prisma.transaction.findMany({
+        where: { userId, date: { gte: startDate, lte: endDate } },
+      }),
+    ]);
 
-    if (budgets.length === 0) {
-      return [];
-    }
+    const categories: CategoryLite[] = categoriesRaw.map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type as TransactionType,
+      parentId: c.parentId,
+      sortOrder: c.sortOrder,
+    }));
 
-    const transactions = await this.prisma.transaction.findMany({
-      where: {
-        userId,
-        date: { gte: startDate, lte: endDate },
-      },
-    });
+    if (categories.length === 0) return [];
 
-    const actualByCategory = new Map<string, number>();
+    // leaf 실적 집계
+    const leafActual = new Map<string, number>();
     for (const tx of transactions) {
-      const current = actualByCategory.get(tx.categoryId) ?? 0;
-      actualByCategory.set(tx.categoryId, current + tx.amount);
+      leafActual.set(tx.categoryId, (leafActual.get(tx.categoryId) ?? 0) + tx.amount);
     }
 
-    return budgets.map((budget) => {
-      const actual = actualByCategory.get(budget.categoryId) ?? 0;
-      const difference = budget.amount - actual;
-      const achievementRate =
-        budget.amount > 0 ? actual / budget.amount : actual > 0 ? 1 : 0;
+    // 부모 rollup 계산: 부모 actual = 자식 leaf actual 합 + 부모 자신의 leaf actual
+    // (트랜잭션은 leaf에만 연결되는 원칙이지만, 마이그레이션 중간 상태 대비 안전하게 합산)
+    const childrenByParent = new Map<string, string[]>();
+    for (const cat of categories) {
+      if (cat.parentId) {
+        const arr = childrenByParent.get(cat.parentId) ?? [];
+        arr.push(cat.id);
+        childrenByParent.set(cat.parentId, arr);
+      }
+    }
+
+    const effectiveActual = new Map<string, number>();
+    for (const cat of categories) {
+      const childIds = childrenByParent.get(cat.id) ?? [];
+      let sum = leafActual.get(cat.id) ?? 0;
+      for (const cid of childIds) {
+        sum += leafActual.get(cid) ?? 0;
+      }
+      effectiveActual.set(cat.id, sum);
+    }
+
+    // 예산 인덱스
+    const budgetByCategory = new Map<string, { id: string; amount: number; type: TransactionType }>();
+    for (const b of budgets) {
+      budgetByCategory.set(b.categoryId, {
+        id: b.id,
+        amount: b.amount,
+        type: b.type as TransactionType,
+      });
+    }
+
+    // 추천 예산: 직전 N개월 실적 평균 (leaf에만; 부모는 자식 합)
+    const recommendations = await this.computeRecommendations(
+      userId,
+      year,
+      month,
+      categories,
+      childrenByParent,
+    );
+
+    // 조립
+    return categories.map((cat) => {
+      const budget = budgetByCategory.get(cat.id);
+      const actual = effectiveActual.get(cat.id) ?? 0;
+      const isParent = (childrenByParent.get(cat.id) ?? []).length > 0;
+      const isBudgeted = budget !== undefined;
+      const budgetAmount = budget?.amount ?? 0;
+      const difference = budgetAmount - actual;
+      const achievementRate = this.computeAchievementRate(budgetAmount, actual);
 
       let status: BudgetStatus;
-      if (budget.type === 'INCOME') {
+      if (!isBudgeted) {
+        status = 'UNSET';
+      } else if (cat.type === 'INCOME') {
         status = this.evaluateIncomeStatus(achievementRate);
       } else {
         status = this.evaluateExpenseStatus(achievementRate);
       }
 
       return {
-        categoryId: budget.categoryId,
-        categoryName: budget.category.name,
-        type: budget.type as BudgetAnalysisItem['type'],
-        budget: budget.amount,
+        categoryId: cat.id,
+        categoryName: cat.name,
+        type: cat.type,
+        parentId: cat.parentId,
+        isParent,
+        isBudgeted,
+        budget: budgetAmount,
         actual,
         difference,
         achievementRate: Math.round(achievementRate * 10000) / 100,
         status,
+        recommendation: recommendations.get(cat.id) ?? 0,
       };
     });
   }
 
+  // ─── Helpers ────────────────────────────────────────────────────────────
+
+  private computeAchievementRate(budget: number, actual: number): number {
+    if (budget > 0) return actual / budget;
+    return actual > 0 ? 1 : 0;
+  }
+
   private evaluateExpenseStatus(achievementRate: number): BudgetStatus {
-    if (achievementRate > ACHIEVEMENT_100) {
-      return 'OVER';
-    }
-    if (achievementRate >= WARNING_THRESHOLD) {
-      return 'WARNING';
-    }
+    if (achievementRate > ACHIEVEMENT_100) return 'OVER';
+    if (achievementRate >= WARNING_THRESHOLD) return 'WARNING';
     return 'GOOD';
   }
 
   private evaluateIncomeStatus(achievementRate: number): BudgetStatus {
-    if (achievementRate >= ACHIEVEMENT_100) {
-      return 'GOOD';
-    }
-    if (achievementRate >= WARNING_THRESHOLD) {
-      return 'WARNING';
-    }
+    if (achievementRate >= ACHIEVEMENT_100) return 'GOOD';
+    if (achievementRate >= WARNING_THRESHOLD) return 'WARNING';
     return 'OVER';
+  }
+
+  private async computeRecommendations(
+    userId: string,
+    year: number,
+    month: number,
+    categories: CategoryLite[],
+    childrenByParent: Map<string, string[]>,
+  ): Promise<Map<string, number>> {
+    const startMonth = new Date(year, month - 1 - RECOMMENDATION_LOOKBACK_MONTHS, 1);
+    const endMonth = new Date(year, month - 1, 0); // 이번 달 이전 (0일 = 전달 마지막 날)
+
+    const priorTransactions = await this.prisma.transaction.findMany({
+      where: {
+        userId,
+        date: { gte: startMonth, lte: endMonth },
+      },
+    });
+
+    const leafSum = new Map<string, number>();
+    for (const tx of priorTransactions) {
+      leafSum.set(tx.categoryId, (leafSum.get(tx.categoryId) ?? 0) + tx.amount);
+    }
+
+    const recommendations = new Map<string, number>();
+    const monthsDivisor = Math.max(RECOMMENDATION_LOOKBACK_MONTHS, 1);
+
+    for (const cat of categories) {
+      const childIds = childrenByParent.get(cat.id) ?? [];
+      let total = leafSum.get(cat.id) ?? 0;
+      for (const cid of childIds) {
+        total += leafSum.get(cid) ?? 0;
+      }
+      const avg = total / monthsDivisor;
+      // 1000원 단위 반올림 (UX용)
+      recommendations.set(cat.id, Math.round(avg / 1000) * 1000);
+    }
+
+    return recommendations;
   }
 }

--- a/apps/api/src/migration/migration.service.ts
+++ b/apps/api/src/migration/migration.service.ts
@@ -44,9 +44,15 @@ export class MigrationService {
 
     for (const item of dto.items) {
       try {
-        const category = await this.prisma.category.findFirst({
-          where: { name: item.categoryName, type: item.type },
-        });
+        // 2-depth 도입 이후: CSV categoryName은 기본적으로 루트 카테고리로 간주.
+        // 같은 name+type이 여러 parent 아래 존재해도 parentId=null 레거시로 우선 매칭.
+        const category =
+          (await this.prisma.category.findFirst({
+            where: { name: item.categoryName, type: item.type, parentId: null },
+          })) ??
+          (await this.prisma.category.findFirst({
+            where: { name: item.categoryName, type: item.type },
+          }));
 
         if (!category) {
           skipped++;
@@ -94,9 +100,14 @@ export class MigrationService {
 
     for (const item of dto.items) {
       try {
-        const category = await this.prisma.category.findFirst({
-          where: { name: item.categoryName, type: item.type },
-        });
+        // 2-depth 도입 이후: CSV categoryName은 기본적으로 루트 카테고리로 간주.
+        const category =
+          (await this.prisma.category.findFirst({
+            where: { name: item.categoryName, type: item.type, parentId: null },
+          })) ??
+          (await this.prisma.category.findFirst({
+            where: { name: item.categoryName, type: item.type },
+          }));
 
         if (!category) {
           skipped++;

--- a/apps/web/app/(main)/budget/analysis/page.tsx
+++ b/apps/web/app/(main)/budget/analysis/page.tsx
@@ -1,42 +1,35 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from '@/components/ui/table';
 import { Separator } from '@/components/ui/separator';
 import { MonthPicker } from '@/components/common/month-picker';
-import { AmountDisplay } from '@/components/common/amount-display';
-import { StatusBadge } from '@/components/common/status-badge';
 import { BudgetChart } from '@/components/budget/budget-chart';
-import { BudgetProgress } from '@/components/budget/budget-progress';
 import { BudgetForm } from '@/components/budget/budget-form';
+import { BudgetAnalysisTree } from '@/components/budget/budget-analysis-tree';
+import { BudgetCompletionMeter } from '@/components/budget/budget-completion-meter';
 import { ApplyAllDialog } from '@/components/budget/apply-all-dialog';
 import { useBudgets, useBudgetAnalysis, useCategories } from '@/hooks/use-budget';
-import { getCategoryColor } from '@/lib/category-colors';
-import type { Budget, CreateBudgetDto, UpdateBudgetDto } from '@/lib/api/budget';
+import type {
+  Budget,
+  CreateBudgetDto,
+  UpdateBudgetDto,
+} from '@/lib/api/budget';
 import type { TransactionType } from '@my-wallet/shared';
-import { BarChart3, Plus, Pencil, Trash2, Settings2, Copy } from 'lucide-react';
+import { BarChart3, Plus, Settings2, Copy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 
-const TYPE_LABELS: Record<TransactionType, string> = {
-  INCOME: '수입',
-  EXPENSE: '지출',
-  SAVING: '저축',
-};
+// ─── Tabs ─────────────────────────────────────────────────────────────────────
 
-const TYPE_VARIANTS: Record<TransactionType, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  INCOME: 'default',
-  EXPENSE: 'destructive',
-  SAVING: 'secondary',
-};
+const TABS: Array<{ key: TransactionType; label: string }> = [
+  { key: 'EXPENSE', label: '지출' },
+  { key: 'SAVING', label: '저축' },
+  { key: 'INCOME', label: '수입' },
+];
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function BudgetAnalysisPage() {
   const [selectedDate, setSelectedDate] = useState(() => {
@@ -48,27 +41,79 @@ export default function BudgetAnalysisPage() {
   const month = selectedDate.getMonth() + 1;
   const monthStr = `${year}-${String(month).padStart(2, '0')}`;
 
+  const [activeTab, setActiveTab] = useState<TransactionType>('EXPENSE');
+
   const [budgetFormOpen, setBudgetFormOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
+  const [prefilledCategoryId, setPrefilledCategoryId] = useState<string | null>(null);
+  const [prefilledAmount, setPrefilledAmount] = useState<number>(0);
   const [applyAllOpen, setApplyAllOpen] = useState(false);
 
-  const { budgets, loading: budgetsLoading, create, update, remove, refetch: refreshBudgets } = useBudgets(year, month);
-  const { analysis, loading: analysisLoading, refetch: refreshAnalysis } = useBudgetAnalysis(year, month);
+  const {
+    budgets,
+    loading: budgetsLoading,
+    create,
+    update,
+    remove,
+    refetch: refreshBudgets,
+  } = useBudgets(year, month);
+  const {
+    analysis,
+    loading: analysisLoading,
+    refetch: refreshAnalysis,
+  } = useBudgetAnalysis(year, month);
   const { categories } = useCategories();
+
+  // 탭별 필터링된 분석 데이터
+  const tabItems = useMemo(
+    () => analysis.filter((item) => item.type === activeTab),
+    [analysis, activeTab],
+  );
+
+  // 완료도 계산: 이 탭의 leaf 카테고리 기준
+  const completion = useMemo(() => {
+    const leaves = tabItems.filter((item) => !item.isParent);
+    const completed = leaves.filter((item) => item.isBudgeted).length;
+    return { completed, total: leaves.length };
+  }, [tabItems]);
+
+  const chartData = useMemo(
+    () => tabItems.filter((i) => i.isBudgeted && !i.isParent),
+    [tabItems],
+  );
+
+  // ─── Handlers ────────────────────────────────────────────────────────────
 
   const handleAddBudget = () => {
     setEditingBudget(null);
+    setPrefilledCategoryId(null);
+    setPrefilledAmount(0);
     setBudgetFormOpen(true);
   };
 
-  const handleEditBudget = (budget: Budget) => {
-    setEditingBudget(budget);
+  const handleInlineAdd = (categoryId: string, recommendation: number) => {
+    setEditingBudget(null);
+    setPrefilledCategoryId(categoryId);
+    setPrefilledAmount(recommendation);
     setBudgetFormOpen(true);
   };
 
-  const handleDeleteBudget = async (id: string) => {
-    if (!confirm('예산을 삭제하시겠습니까?')) return;
-    await remove(id);
+  const handleEditBudget = (categoryId: string) => {
+    const target = budgets.find((b) => b.categoryId === categoryId);
+    if (!target) return;
+    setEditingBudget(target);
+    setPrefilledCategoryId(null);
+    setPrefilledAmount(0);
+    setBudgetFormOpen(true);
+  };
+
+  const handleRemoveBudget = async (categoryId: string) => {
+    const target = budgets.find((b) => b.categoryId === categoryId);
+    if (!target) return;
+    if (!confirm(`${target.category?.name ?? '해당 카테고리'} 예산을 삭제하시겠습니까?`))
+      return;
+    await remove(target.id);
+    refreshAnalysis();
   };
 
   const handleBudgetSubmit = async (dto: CreateBudgetDto | UpdateBudgetDto) => {
@@ -77,23 +122,56 @@ export default function BudgetAnalysisPage() {
     } else {
       await create(dto as CreateBudgetDto);
     }
+    refreshAnalysis();
   };
+
+  // ─── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-2xl font-bold">예산 분석</h1>
-        <MonthPicker value={selectedDate} onChange={setSelectedDate} />
+        <div className="flex items-center gap-2">
+          <Link
+            href="/settings/categories"
+            className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+          >
+            카테고리 관리
+          </Link>
+          <MonthPicker value={selectedDate} onChange={setSelectedDate} />
+        </div>
       </div>
 
-      {/* Budget Settings */}
+      {/* Tabs */}
+      <div className="flex items-center gap-1 border-b">
+        {TABS.map((tab) => {
+          const isActive = tab.key === activeTab;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px',
+                isActive
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Completion Meter + Actions */}
       <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-4 flex-wrap">
             <CardTitle className="flex items-center gap-2 text-base">
               <Settings2 className="h-4 w-4" />
-              예산 설정
+              예산 설정 현황
             </CardTitle>
             <div className="flex items-center gap-2">
               <Button
@@ -106,178 +184,71 @@ export default function BudgetAnalysisPage() {
                 <Copy className="h-3.5 w-3.5" />
                 올해 일괄 적용
               </Button>
-              <Button size="sm" variant="outline" onClick={handleAddBudget} className="gap-1.5">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleAddBudget}
+                className="gap-1.5"
+              >
                 <Plus className="h-3.5 w-3.5" />
                 예산 추가
               </Button>
             </div>
           </div>
         </CardHeader>
+        <CardContent>
+          <BudgetCompletionMeter
+            completed={completion.completed}
+            total={completion.total}
+            label={`${TABS.find((t) => t.key === activeTab)?.label} 카테고리 예산 설정`}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Analysis Tree */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">상세 분석 (트리)</CardTitle>
+          <p className="text-xs text-muted-foreground pt-1">
+            대분류 예산은 하위 카테고리 실적 합계에 대한 상한 캡입니다. 자식 예산은 각각 독립적으로 집계됩니다.
+          </p>
+        </CardHeader>
         <CardContent className="p-0">
-          {budgetsLoading ? (
+          {analysisLoading || budgetsLoading ? (
             <div className="space-y-2 p-4">
-              {[1, 2, 3].map((i) => (
+              {[1, 2, 3, 4].map((i) => (
                 <div key={i} className="h-10 bg-muted animate-pulse rounded" />
               ))}
             </div>
-          ) : budgets.length === 0 ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">
-              설정된 예산이 없습니다. 예산을 추가해보세요.
-            </div>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>카테고리</TableHead>
-                  <TableHead>유형</TableHead>
-                  <TableHead className="text-right">예산 금액</TableHead>
-                  <TableHead className="w-20"></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {budgets.map((budget) => (
-                  <TableRow key={budget.id}>
-                    <TableCell className="font-medium">
-                      {(() => {
-                        const catName = budget.category?.name ?? '기타';
-                        const color = getCategoryColor(catName);
-                        return (
-                          <span className={`text-xs px-2 py-0.5 rounded-md ${color.bg} ${color.text}`}>
-                            {catName}
-                          </span>
-                        );
-                      })()}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={TYPE_VARIANTS[budget.type]}>
-                        {TYPE_LABELS[budget.type]}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <AmountDisplay amount={budget.amount} />
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1 justify-end">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleEditBudget(budget)}
-                          aria-label="수정"
-                          className="h-7 w-7"
-                        >
-                          <Pencil className="h-3.5 w-3.5" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDeleteBudget(budget.id)}
-                          aria-label="삭제"
-                          className="h-7 w-7 text-destructive hover:text-destructive"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <BudgetAnalysisTree
+              items={tabItems}
+              onEditBudget={handleEditBudget}
+              onAddBudget={handleInlineAdd}
+              onRemoveBudget={handleRemoveBudget}
+            />
           )}
         </CardContent>
       </Card>
 
       <Separator />
 
-      {/* Analysis Chart */}
+      {/* Chart */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <BarChart3 className="h-4 w-4" />
-            카테고리별 예산 vs 실적
+            설정된 예산 vs 실적
           </CardTitle>
         </CardHeader>
         <CardContent>
           {analysisLoading ? (
             <div className="h-48 bg-muted animate-pulse rounded" />
           ) : (
-            <BudgetChart data={analysis} />
+            <BudgetChart data={chartData} />
           )}
         </CardContent>
       </Card>
-
-      {/* Analysis Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">상세 분석</CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          {analysisLoading ? (
-            <div className="space-y-2 p-4">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-10 bg-muted animate-pulse rounded" />
-              ))}
-            </div>
-          ) : analysis.length === 0 ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">
-              분석할 데이터가 없습니다.
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>카테고리</TableHead>
-                  <TableHead className="text-right">예산</TableHead>
-                  <TableHead className="text-right">실적</TableHead>
-                  <TableHead className="text-right">차이</TableHead>
-                  <TableHead className="text-right">달성률</TableHead>
-                  <TableHead>상태</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {analysis.map((item) => (
-                  <TableRow key={item.categoryId}>
-                    <TableCell className="font-medium">{item.categoryName}</TableCell>
-                    <TableCell className="text-right">
-                      <AmountDisplay amount={item.budget} />
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <AmountDisplay amount={item.actual} />
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <AmountDisplay
-                        amount={item.difference}
-                        showSign
-                      />
-                    </TableCell>
-                    <TableCell className="text-right text-sm tabular-nums">
-                      {item.achievementRate.toFixed(1)}%
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={item.status} />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Progress Bars */}
-      {analysis.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">카테고리별 달성률</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="divide-y">
-              {analysis.map((item) => (
-                <BudgetProgress key={item.categoryId} item={item} />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Budget Form Dialog */}
       <BudgetForm
@@ -287,6 +258,8 @@ export default function BudgetAnalysisPage() {
         budget={editingBudget}
         month={monthStr}
         onSubmit={handleBudgetSubmit}
+        prefilledCategoryId={prefilledCategoryId}
+        prefilledAmount={prefilledAmount}
       />
 
       {/* Apply All Dialog */}
@@ -303,3 +276,4 @@ export default function BudgetAnalysisPage() {
     </div>
   );
 }
+

--- a/apps/web/app/(main)/settings/categories/page.tsx
+++ b/apps/web/app/(main)/settings/categories/page.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useCategoryTree } from '@/hooks/use-budget';
+import {
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  type CreateCategoryDto,
+  type UpdateCategoryDto,
+} from '@/lib/api/budget';
+import { CategoryEditorDialog, type CategoryEditorSubmit } from '@/components/settings/category-editor-dialog';
+import type { TransactionType, CategoryNode } from '@my-wallet/shared';
+import { cn } from '@/lib/utils';
+import {
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Pencil,
+  Trash2,
+  FolderPlus,
+  FolderTree,
+} from 'lucide-react';
+
+// ─── Tabs ─────────────────────────────────────────────────────────────────────
+
+const TABS: Array<{ key: TransactionType; label: string }> = [
+  { key: 'EXPENSE', label: '지출' },
+  { key: 'SAVING', label: '저축' },
+  { key: 'INCOME', label: '수입' },
+];
+
+// ─── Dialog state ─────────────────────────────────────────────────────────────
+
+type DialogState =
+  | { mode: 'closed' }
+  | {
+      mode: 'create-root';
+      type: TransactionType;
+    }
+  | {
+      mode: 'create-child';
+      type: TransactionType;
+      parent: CategoryNode;
+    }
+  | {
+      mode: 'edit';
+      node: CategoryNode;
+    };
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function CategoriesPage() {
+  const [activeTab, setActiveTab] = useState<TransactionType>('EXPENSE');
+  const [dialog, setDialog] = useState<DialogState>({ mode: 'closed' });
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const { tree, loading, error, refetch } = useCategoryTree(activeTab);
+
+  const stats = useMemo(() => {
+    let parents = 0;
+    let leaves = 0;
+    for (const root of tree) {
+      if (root.children.length > 0) {
+        parents += 1;
+        leaves += root.children.length;
+      } else {
+        leaves += 1;
+      }
+    }
+    return { parents, leaves, total: parents + leaves };
+  }, [tree]);
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // ─── Handlers ────────────────────────────────────────────────────────────
+
+  const handleSubmit = async (data: CategoryEditorSubmit) => {
+    if (dialog.mode === 'closed') return;
+
+    if (dialog.mode === 'create-root') {
+      const dto: CreateCategoryDto = {
+        name: data.name,
+        type: dialog.type,
+        parentId: null,
+        sortOrder: data.sortOrder,
+      };
+      await createCategory(dto);
+    } else if (dialog.mode === 'create-child') {
+      const dto: CreateCategoryDto = {
+        name: data.name,
+        type: dialog.type,
+        parentId: dialog.parent.id,
+        sortOrder: data.sortOrder,
+      };
+      await createCategory(dto);
+    } else if (dialog.mode === 'edit') {
+      const dto: UpdateCategoryDto = {
+        name: data.name,
+        sortOrder: data.sortOrder,
+      };
+      if (data.parentId !== undefined) {
+        dto.parentId = data.parentId;
+      }
+      await updateCategory(dialog.node.id, dto);
+    }
+    refetch();
+  };
+
+  const handleDelete = async (node: CategoryNode) => {
+    const msg = node.children.length > 0
+      ? `"${node.name}" 대분류 아래에 ${node.children.length}개의 소분류가 있습니다. 소분류를 먼저 정리해주세요.`
+      : `"${node.name}" 카테고리를 삭제하시겠습니까? 연결된 거래가 있으면 비활성화됩니다.`;
+
+    if (node.children.length > 0) {
+      alert(msg);
+      return;
+    }
+    if (!confirm(msg)) return;
+    try {
+      await deleteCategory(node.id);
+      refetch();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : '삭제에 실패했습니다.');
+    }
+  };
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <FolderTree className="h-5 w-5" />
+          <h1 className="text-2xl font-bold">카테고리 관리</h1>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex items-center gap-1 border-b">
+        {TABS.map((tab) => {
+          const isActive = tab.key === activeTab;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px',
+                isActive
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <div className="flex items-center gap-3 flex-wrap">
+              <CardTitle className="text-base">
+                {TABS.find((t) => t.key === activeTab)?.label} 카테고리 트리
+              </CardTitle>
+              <div className="flex gap-1.5">
+                <Badge variant="outline" className="text-xs">
+                  대분류 {stats.parents}
+                </Badge>
+                <Badge variant="outline" className="text-xs">
+                  소분류 {stats.leaves}
+                </Badge>
+              </div>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => setDialog({ mode: 'create-root', type: activeTab })}
+              className="gap-1.5"
+            >
+              <FolderPlus className="h-3.5 w-3.5" />
+              대분류 추가
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="space-y-2 p-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-10 bg-muted animate-pulse rounded" />
+              ))}
+            </div>
+          ) : error ? (
+            <div className="py-8 text-center text-destructive text-sm">{error}</div>
+          ) : tree.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground text-sm">
+              카테고리가 없습니다. "대분류 추가"로 시작해주세요.
+            </div>
+          ) : (
+            <div className="divide-y">
+              {tree.map((root) => {
+                const hasChildren = root.children.length > 0;
+                const isExpanded = !collapsed.has(root.id);
+                return (
+                  <div key={root.id}>
+                    <RootRow
+                      node={root}
+                      hasChildren={hasChildren}
+                      expanded={isExpanded}
+                      onToggle={() => toggle(root.id)}
+                      onEdit={() => setDialog({ mode: 'edit', node: root })}
+                      onDelete={() => handleDelete(root)}
+                      onAddChild={() =>
+                        setDialog({ mode: 'create-child', type: activeTab, parent: root })
+                      }
+                    />
+                    {hasChildren && isExpanded && (
+                      <div className="bg-muted/20">
+                        {root.children.map((child) => (
+                          <LeafRow
+                            key={child.id}
+                            node={child}
+                            onEdit={() => setDialog({ mode: 'edit', node: child })}
+                            onDelete={() => handleDelete(child)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <CategoryEditorDialog
+        open={dialog.mode !== 'closed'}
+        onOpenChange={(next) => !next && setDialog({ mode: 'closed' })}
+        mode={
+          dialog.mode === 'create-root'
+            ? 'create-root'
+            : dialog.mode === 'create-child'
+              ? 'create-child'
+              : 'edit'
+        }
+        type={
+          dialog.mode === 'edit'
+            ? (dialog.node.type as TransactionType)
+            : dialog.mode !== 'closed'
+              ? dialog.type
+              : activeTab
+        }
+        parentName={dialog.mode === 'create-child' ? dialog.parent.name : undefined}
+        initialName={dialog.mode === 'edit' ? dialog.node.name : ''}
+        initialSortOrder={dialog.mode === 'edit' ? dialog.node.sortOrder : 0}
+        initialParentId={dialog.mode === 'edit' ? dialog.node.parentId : null}
+        parentOptions={tree.map((root) => ({ id: root.id, name: root.name }))}
+        hasChildren={dialog.mode === 'edit' ? dialog.node.children.length > 0 : false}
+        editingId={dialog.mode === 'edit' ? dialog.node.id : undefined}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  );
+}
+
+// ─── Rows ─────────────────────────────────────────────────────────────────────
+
+function RootRow({
+  node,
+  hasChildren,
+  expanded,
+  onToggle,
+  onEdit,
+  onDelete,
+  onAddChild,
+}: {
+  node: CategoryNode;
+  hasChildren: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onAddChild: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-3">
+      {hasChildren ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={expanded ? '접기' : '펼치기'}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+        </button>
+      ) : (
+        <span className="w-4" />
+      )}
+      <span className="font-medium">{node.name}</span>
+      <span className="text-xs text-muted-foreground">#{node.sortOrder}</span>
+      {hasChildren && (
+        <Badge variant="secondary" className="text-xs">
+          {node.children.length}개 소분류
+        </Badge>
+      )}
+      <div className="ml-auto flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onAddChild}
+          className="h-7 gap-1 text-xs"
+          aria-label="소분류 추가"
+        >
+          <Plus className="h-3 w-3" />
+          소분류
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onEdit}
+          aria-label="수정"
+          className="h-7 w-7"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onDelete}
+          aria-label="삭제"
+          className="h-7 w-7 text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function LeafRow({
+  node,
+  onEdit,
+  onDelete,
+}: {
+  node: CategoryNode;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 pl-10 pr-4 py-2.5 border-t border-border/50">
+      <span className="text-sm">{node.name}</span>
+      <span className="text-xs text-muted-foreground">#{node.sortOrder}</span>
+      <div className="ml-auto flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onEdit}
+          aria-label="수정"
+          className="h-7 w-7"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onDelete}
+          aria-label="삭제"
+          className="h-7 w-7 text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(main)/settings/page.tsx
+++ b/apps/web/app/(main)/settings/page.tsx
@@ -1,269 +1,33 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import {
-  fetchCategories,
-  createCategory,
-  updateCategory,
-  deleteCategory,
-  type Category,
-  type CreateCategoryDto,
-} from '@/lib/api/budget';
-import { getCategoryColor } from '@/lib/category-colors';
-import type { TransactionType } from '@my-wallet/shared';
-import { Settings, Plus, Pencil, Trash2, GripVertical } from 'lucide-react';
-
-const TYPE_LABELS: Record<TransactionType, string> = {
-  INCOME: '수입',
-  EXPENSE: '지출',
-  SAVING: '저축',
-};
-
-const TYPE_TABS: TransactionType[] = ['EXPENSE', 'INCOME', 'SAVING'];
+import { FolderTree, ChevronRight } from 'lucide-react';
 
 export default function SettingsPage() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<TransactionType>('EXPENSE');
-
-  // Form state
-  const [formOpen, setFormOpen] = useState(false);
-  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
-  const [formName, setFormName] = useState('');
-  const [formType, setFormType] = useState<TransactionType>('EXPENSE');
-  const [formError, setFormError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  const loadCategories = useCallback(async () => {
-    try {
-      const data = await fetchCategories();
-      setCategories(data);
-    } catch {
-      // 에러 무시
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadCategories();
-  }, [loadCategories]);
-
-  const filtered = categories.filter((c) => c.type === activeTab);
-
-  const handleAdd = () => {
-    setEditingCategory(null);
-    setFormName('');
-    setFormType(activeTab);
-    setFormError(null);
-    setFormOpen(true);
-  };
-
-  const handleEdit = (cat: Category) => {
-    setEditingCategory(cat);
-    setFormName(cat.name);
-    setFormType(cat.type);
-    setFormError(null);
-    setFormOpen(true);
-  };
-
-  const handleDelete = async (cat: Category) => {
-    if (!confirm(`"${cat.name}" 카테고리를 삭제하시겠습니까?`)) return;
-    try {
-      await deleteCategory(cat.id);
-      await loadCategories();
-    } catch (err: unknown) {
-      alert(err instanceof Error ? err.message : '삭제에 실패했습니다.');
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!formName.trim()) {
-      setFormError('카테고리 이름을 입력해주세요.');
-      return;
-    }
-
-    setSubmitting(true);
-    setFormError(null);
-    try {
-      if (editingCategory) {
-        await updateCategory(editingCategory.id, { name: formName.trim() });
-      } else {
-        const dto: CreateCategoryDto = {
-          name: formName.trim(),
-          type: formType,
-          sortOrder: filtered.length,
-        };
-        await createCategory(dto);
-      }
-      await loadCategories();
-      setFormOpen(false);
-    } catch (err: unknown) {
-      setFormError(err instanceof Error ? err.message : '저장에 실패했습니다.');
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">설정</h1>
 
-      {/* 카테고리 관리 */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle className="flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            카테고리 관리
-          </CardTitle>
-          <Button size="sm" onClick={handleAdd} className="gap-1.5">
-            <Plus className="h-4 w-4" />
-            추가
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {/* 유형 탭 */}
-          <div className="flex gap-1 mb-4 bg-muted p-1 rounded-lg">
-            {TYPE_TABS.map((t) => (
-              <button
-                key={t}
-                onClick={() => setActiveTab(t)}
-                className={`flex-1 py-1.5 px-3 rounded-md text-sm font-medium transition-colors ${
-                  activeTab === t
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {TYPE_LABELS[t]}
-              </button>
-            ))}
-          </div>
-
-          {/* 카테고리 목록 */}
-          {loading ? (
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-12 bg-muted animate-pulse rounded" />
-              ))}
-            </div>
-          ) : filtered.length === 0 ? (
-            <div className="py-8 text-center text-muted-foreground text-sm">
-              {TYPE_LABELS[activeTab]} 카테고리가 없습니다.
-            </div>
-          ) : (
-            <div className="space-y-1">
-              {filtered.map((cat) => {
-                const color = getCategoryColor(cat.name);
-                return (
-                  <div
-                    key={cat.id}
-                    className="group flex items-center justify-between py-2.5 px-3 rounded-md hover:bg-muted/50 transition-colors"
-                  >
-                    <div className="flex items-center gap-3">
-                      <GripVertical className="h-4 w-4 text-muted-foreground/40" />
-                      <span
-                        className={`text-xs px-2 py-0.5 rounded-md font-medium ${color.bg} ${color.text}`}
-                      >
-                        {cat.name}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleEdit(cat)}
-                        className="h-7 w-7"
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(cat)}
-                        className="h-7 w-7 text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* 카테고리 추가/수정 다이얼로그 */}
-      <Dialog open={formOpen} onOpenChange={setFormOpen}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>
-              {editingCategory ? '카테고리 수정' : '카테고리 추가'}
-            </DialogTitle>
-          </DialogHeader>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {!editingCategory && (
-              <div className="space-y-1.5">
-                <label className="text-sm font-medium">유형</label>
-                <Select value={formType} onValueChange={(v) => setFormType(v as TransactionType)}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {TYPE_TABS.map((t) => (
-                      <SelectItem key={t} value={t}>
-                        {TYPE_LABELS[t]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium">이름</label>
-              <Input
-                value={formName}
-                onChange={(e) => setFormName(e.target.value)}
-                placeholder="카테고리 이름"
-                autoFocus
-              />
-            </div>
-            {formError && <p className="text-sm text-destructive">{formError}</p>}
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setFormOpen(false)}
-                disabled={submitting}
-              >
-                취소
-              </Button>
-              <Button type="submit" disabled={submitting}>
-                {submitting ? '저장 중...' : editingCategory ? '수정' : '추가'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/settings/categories"
+          className="block transition-colors hover:bg-accent/40 rounded-lg"
+        >
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <FolderTree className="h-5 w-5" />
+                카테고리 관리
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>대분류 / 소분류 2단계 카테고리 트리 관리</span>
+              <ChevronRight className="h-4 w-4" />
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/budget/budget-analysis-tree.tsx
+++ b/apps/web/components/budget/budget-analysis-tree.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { BudgetAnalysisItem } from '@my-wallet/shared';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { AmountDisplay } from '@/components/common/amount-display';
+import { StatusBadge } from '@/components/common/status-badge';
+import {
+  ChevronRight,
+  ChevronDown,
+  Pencil,
+  Trash2,
+  Plus,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  Info,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SortKey = 'name' | 'budget' | 'actual' | 'rate';
+export type SortDir = 'asc' | 'desc';
+
+interface BudgetAnalysisTreeProps {
+  items: BudgetAnalysisItem[];
+  onEditBudget: (categoryId: string) => void;
+  onAddBudget: (categoryId: string, recommendation: number) => void;
+  onRemoveBudget: (categoryId: string) => void;
+}
+
+interface TreeNode {
+  item: BudgetAnalysisItem;
+  children: BudgetAnalysisItem[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildTree(items: BudgetAnalysisItem[]): TreeNode[] {
+  const byId = new Map<string, BudgetAnalysisItem>();
+  for (const it of items) byId.set(it.categoryId, it);
+
+  const roots: TreeNode[] = [];
+  const childrenMap = new Map<string, BudgetAnalysisItem[]>();
+
+  for (const it of items) {
+    if (it.parentId) {
+      const arr = childrenMap.get(it.parentId) ?? [];
+      arr.push(it);
+      childrenMap.set(it.parentId, arr);
+    }
+  }
+
+  for (const it of items) {
+    if (!it.parentId) {
+      roots.push({
+        item: it,
+        children: childrenMap.get(it.categoryId) ?? [],
+      });
+    } else if (!byId.has(it.parentId)) {
+      // 부모가 목록에 없으면(필터 아웃 등) 루트로 승격
+      roots.push({ item: it, children: [] });
+    }
+  }
+
+  return roots;
+}
+
+function compareItems(a: BudgetAnalysisItem, b: BudgetAnalysisItem, key: SortKey, dir: SortDir): number {
+  const mult = dir === 'asc' ? 1 : -1;
+  switch (key) {
+    case 'name':
+      return a.categoryName.localeCompare(b.categoryName, 'ko') * mult;
+    case 'budget':
+      return (a.budget - b.budget) * mult;
+    case 'actual':
+      return (a.actual - b.actual) * mult;
+    case 'rate':
+      return (a.achievementRate - b.achievementRate) * mult;
+  }
+}
+
+function sortTree(tree: TreeNode[], key: SortKey, dir: SortDir): TreeNode[] {
+  const sorted = [...tree].sort((na, nb) => compareItems(na.item, nb.item, key, dir));
+  return sorted.map((node) => ({
+    item: node.item,
+    children: [...node.children].sort((a, b) => compareItems(a, b, key, dir)),
+  }));
+}
+
+// ─── Sort Header ──────────────────────────────────────────────────────────────
+
+function SortHeader({
+  label,
+  active,
+  dir,
+  align = 'left',
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  align?: 'left' | 'right';
+  onClick: () => void;
+}) {
+  const icon = !active ? (
+    <ArrowUpDown className="h-3 w-3 opacity-40" />
+  ) : dir === 'asc' ? (
+    <ArrowUp className="h-3 w-3" />
+  ) : (
+    <ArrowDown className="h-3 w-3" />
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-1 text-xs font-medium hover:text-foreground transition-colors',
+        align === 'right' ? 'ml-auto' : '',
+        active ? 'text-foreground' : 'text-muted-foreground',
+      )}
+    >
+      {align === 'right' ? (
+        <>
+          {icon}
+          {label}
+        </>
+      ) : (
+        <>
+          {label}
+          {icon}
+        </>
+      )}
+    </button>
+  );
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+function Row({
+  item,
+  depth,
+  isParent,
+  expanded,
+  onToggle,
+  onEditBudget,
+  onAddBudget,
+  onRemoveBudget,
+}: {
+  item: BudgetAnalysisItem;
+  depth: number;
+  isParent: boolean;
+  expanded?: boolean;
+  onToggle?: () => void;
+  onEditBudget: (id: string) => void;
+  onAddBudget: (id: string, rec: number) => void;
+  onRemoveBudget: (id: string) => void;
+}) {
+  const indent = depth * 20;
+  const isUnset = !item.isBudgeted;
+
+  return (
+    <TableRow className={isUnset ? 'bg-muted/20' : ''}>
+      <TableCell className="font-medium">
+        <div className="flex items-center gap-1" style={{ paddingLeft: indent }}>
+          {isParent ? (
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-label={expanded ? '접기' : '펼치기'}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              {expanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </button>
+          ) : (
+            <span className="w-4" />
+          )}
+          <span className={cn('text-sm', isUnset && 'text-muted-foreground')}>
+            {item.categoryName}
+          </span>
+          {isParent && item.isBudgeted && (
+            <span
+              title="부모 예산은 하위 카테고리 합계의 상한 캡입니다. 자식 각각의 예산은 독립적으로 집계됩니다."
+              className="inline-flex items-center"
+              aria-label="부모 예산 안내"
+            >
+              <Info className="h-3 w-3 text-muted-foreground/60" />
+            </span>
+          )}
+        </div>
+      </TableCell>
+      <TableCell className="text-right">
+        {isUnset ? (
+          <span className="text-xs text-muted-foreground">—</span>
+        ) : (
+          <AmountDisplay amount={item.budget} />
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <AmountDisplay amount={item.actual} />
+      </TableCell>
+      <TableCell className="text-right">
+        {isUnset ? (
+          <span className="text-xs text-muted-foreground">—</span>
+        ) : (
+          <AmountDisplay amount={item.difference} showSign />
+        )}
+      </TableCell>
+      <TableCell className="text-right text-sm tabular-nums">
+        {isUnset ? (
+          <span className="text-xs text-muted-foreground">—</span>
+        ) : (
+          `${item.achievementRate.toFixed(1)}%`
+        )}
+      </TableCell>
+      <TableCell>
+        <StatusBadge status={item.status} />
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-1 justify-end">
+          {isUnset ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                onAddBudget(item.categoryId, item.recommendation)
+              }
+              className="h-7 gap-1 text-xs"
+              aria-label={`${item.categoryName} 예산 설정`}
+            >
+              <Plus className="h-3 w-3" />
+              설정
+              {item.recommendation > 0 && (
+                <span className="text-muted-foreground">
+                  (추천{' '}
+                  {new Intl.NumberFormat('ko-KR').format(item.recommendation)}
+                  )
+                </span>
+              )}
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onEditBudget(item.categoryId)}
+                aria-label={`${item.categoryName} 예산 수정`}
+                className="h-7 w-7"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemoveBudget(item.categoryId)}
+                aria-label={`${item.categoryName} 예산 삭제`}
+                className="h-7 w-7 text-destructive hover:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function BudgetAnalysisTree({
+  items,
+  onEditBudget,
+  onAddBudget,
+  onRemoveBudget,
+}: BudgetAnalysisTreeProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const tree = useMemo(() => buildTree(items), [items]);
+  const sorted = useMemo(() => sortTree(tree, sortKey, sortDir), [tree, sortKey, sortDir]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'name' ? 'asc' : 'desc');
+    }
+  };
+
+  const toggle = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="py-8 text-center text-muted-foreground text-sm">
+        이 유형의 활성 카테고리가 없습니다. 설정 → 카테고리 관리에서 추가해주세요.
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-1/3">
+            <SortHeader
+              label="카테고리"
+              active={sortKey === 'name'}
+              dir={sortDir}
+              onClick={() => handleSort('name')}
+            />
+          </TableHead>
+          <TableHead className="text-right">
+            <SortHeader
+              label="예산"
+              active={sortKey === 'budget'}
+              dir={sortDir}
+              align="right"
+              onClick={() => handleSort('budget')}
+            />
+          </TableHead>
+          <TableHead className="text-right">
+            <SortHeader
+              label="실적"
+              active={sortKey === 'actual'}
+              dir={sortDir}
+              align="right"
+              onClick={() => handleSort('actual')}
+            />
+          </TableHead>
+          <TableHead className="text-right">차이</TableHead>
+          <TableHead className="text-right">
+            <SortHeader
+              label="달성률"
+              active={sortKey === 'rate'}
+              dir={sortDir}
+              align="right"
+              onClick={() => handleSort('rate')}
+            />
+          </TableHead>
+          <TableHead>상태</TableHead>
+          <TableHead className="w-28"></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sorted.flatMap((node) => {
+          const hasChildren = node.children.length > 0;
+          const isExpanded = !collapsed.has(node.item.categoryId);
+          const rows = [
+            <Row
+              key={node.item.categoryId}
+              item={node.item}
+              depth={0}
+              isParent={hasChildren}
+              expanded={isExpanded}
+              onToggle={() => toggle(node.item.categoryId)}
+              onEditBudget={onEditBudget}
+              onAddBudget={onAddBudget}
+              onRemoveBudget={onRemoveBudget}
+            />,
+          ];
+          if (hasChildren && isExpanded) {
+            for (const child of node.children) {
+              rows.push(
+                <Row
+                  key={child.categoryId}
+                  item={child}
+                  depth={1}
+                  isParent={false}
+                  onEditBudget={onEditBudget}
+                  onAddBudget={onAddBudget}
+                  onRemoveBudget={onRemoveBudget}
+                />,
+              );
+            }
+          }
+          return rows;
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/components/budget/budget-chart.tsx
+++ b/apps/web/components/budget/budget-chart.tsx
@@ -11,6 +11,7 @@ const STATUS_COLORS: Record<BudgetStatus, string> = {
   GOOD: '#22c55e',
   WARNING: '#f59e0b',
   OVER: '#ef4444',
+  UNSET: '#94a3b8',
 };
 
 const BUDGET_BG = '#e2e8f0';

--- a/apps/web/components/budget/budget-completion-meter.tsx
+++ b/apps/web/components/budget/budget-completion-meter.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Progress } from '@/components/ui/progress';
+
+interface BudgetCompletionMeterProps {
+  completed: number;
+  total: number;
+  label?: string;
+}
+
+export function BudgetCompletionMeter({
+  completed,
+  total,
+  label = '카테고리 예산 설정 진행률',
+}: BudgetCompletionMeterProps) {
+  const percent = total > 0 ? (completed / total) * 100 : 0;
+  const allDone = total > 0 && completed === total;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">{label}</span>
+        <span
+          className={
+            allDone
+              ? 'font-semibold text-good'
+              : 'font-medium tabular-nums'
+          }
+        >
+          {completed}/{total} {allDone ? '완료 ✓' : ''}
+        </span>
+      </div>
+      <Progress
+        value={percent}
+        max={100}
+        aria-label={`예산 설정 ${completed}개 / 전체 ${total}개`}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/budget/budget-form.tsx
+++ b/apps/web/components/budget/budget-form.tsx
@@ -20,6 +20,36 @@ import {
 } from '@/components/ui/select';
 import type { Budget, Category, CreateBudgetDto, UpdateBudgetDto } from '@/lib/api/budget';
 
+// 카테고리를 부모 → 자식 순서로 정렬 (parent 먼저, 그 다음 그 parent의 children)
+function orderCategoriesForDisplay(cats: Category[]): Category[] {
+  const roots = cats.filter((c) => !c.parentId);
+  const childrenByParent = new Map<string, Category[]>();
+  for (const c of cats) {
+    if (c.parentId) {
+      const arr = childrenByParent.get(c.parentId) ?? [];
+      arr.push(c);
+      childrenByParent.set(c.parentId, arr);
+    }
+  }
+  roots.sort((a, b) => a.sortOrder - b.sortOrder);
+  for (const arr of childrenByParent.values()) {
+    arr.sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+  const ordered: Category[] = [];
+  for (const r of roots) {
+    ordered.push(r);
+    const kids = childrenByParent.get(r.id) ?? [];
+    ordered.push(...kids);
+  }
+  // 부모가 목록에 없는 고아 자식들 처리
+  for (const c of cats) {
+    if (c.parentId && !cats.find((p) => p.id === c.parentId)) {
+      if (!ordered.find((o) => o.id === c.id)) ordered.push(c);
+    }
+  }
+  return ordered;
+}
+
 interface BudgetFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -27,6 +57,10 @@ interface BudgetFormProps {
   budget?: Budget | null;
   month: string; // YYYY-MM
   onSubmit: (dto: CreateBudgetDto | UpdateBudgetDto) => Promise<void>;
+  /** 새 예산 추가 시 미리 선택될 카테고리 ID (inline +설정 버튼 용) */
+  prefilledCategoryId?: string | null;
+  /** 새 예산 추가 시 미리 입력될 금액 (추천 금액) */
+  prefilledAmount?: number;
 }
 
 const TYPE_LABELS: Record<TransactionType, string> = {
@@ -44,6 +78,8 @@ export function BudgetForm({
   budget,
   month,
   onSubmit,
+  prefilledCategoryId,
+  prefilledAmount,
 }: BudgetFormProps) {
   const [type, setType] = useState<TransactionType>('EXPENSE');
   const [categoryId, setCategoryId] = useState('');
@@ -56,15 +92,26 @@ export function BudgetForm({
       setType(budget.type);
       setCategoryId(budget.categoryId);
       setAmount(budget.amount.toLocaleString('ko-KR'));
+    } else if (prefilledCategoryId) {
+      const prefilled = categories.find((c) => c.id === prefilledCategoryId);
+      setType(prefilled?.type ?? 'EXPENSE');
+      setCategoryId(prefilledCategoryId);
+      setAmount(
+        prefilledAmount && prefilledAmount > 0
+          ? prefilledAmount.toLocaleString('ko-KR')
+          : '',
+      );
     } else {
       setType('EXPENSE');
       setCategoryId('');
       setAmount('');
     }
     setError(null);
-  }, [budget, open]);
+  }, [budget, open, prefilledCategoryId, prefilledAmount, categories]);
 
-  const filteredCategories = categories.filter((c) => c.type === type);
+  const filteredCategories = orderCategoriesForDisplay(
+    categories.filter((c) => c.type === type),
+  );
 
   const handleTypeChange = (val: string) => {
     setType(val as TransactionType);
@@ -141,7 +188,14 @@ export function BudgetForm({
                 <SelectContent>
                   {filteredCategories.map((c) => (
                     <SelectItem key={c.id} value={c.id}>
-                      {c.name}
+                      {c.parentId ? (
+                        <span>
+                          <span className="text-muted-foreground">└ </span>
+                          {c.name}
+                        </span>
+                      ) : (
+                        <span className="font-medium">{c.name}</span>
+                      )}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/web/components/budget/transaction-form.tsx
+++ b/apps/web/components/budget/transaction-form.tsx
@@ -81,7 +81,31 @@ export function TransactionForm({
     setError(null);
   }, [transaction, open]);
 
-  const filteredCategories = categories.filter((c) => c.type === type);
+  const filteredCategories = (() => {
+    const cats = categories.filter((c) => c.type === type);
+    const roots = cats.filter((c) => !c.parentId).sort((a, b) => a.sortOrder - b.sortOrder);
+    const childrenByParent = new Map<string, typeof cats>();
+    for (const c of cats) {
+      if (c.parentId) {
+        const arr = childrenByParent.get(c.parentId) ?? [];
+        arr.push(c);
+        childrenByParent.set(c.parentId, arr);
+      }
+    }
+    const ordered: typeof cats = [];
+    for (const r of roots) {
+      ordered.push(r);
+      const kids = (childrenByParent.get(r.id) ?? []).sort((a, b) => a.sortOrder - b.sortOrder);
+      ordered.push(...kids);
+    }
+    // 고아 leaf는 끝에 추가
+    for (const c of cats) {
+      if (c.parentId && !cats.find((p) => p.id === c.parentId) && !ordered.find((o) => o.id === c.id)) {
+        ordered.push(c);
+      }
+    }
+    return ordered;
+  })();
 
   const handleTypeChange = (val: string) => {
     setType(val as TransactionType);
@@ -151,7 +175,14 @@ export function TransactionForm({
               <SelectContent>
                 {filteredCategories.map((c) => (
                   <SelectItem key={c.id} value={c.id}>
-                    {c.name}
+                    {c.parentId ? (
+                      <span>
+                        <span className="text-muted-foreground">└ </span>
+                        {c.name}
+                      </span>
+                    ) : (
+                      <span className="font-medium">{c.name}</span>
+                    )}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/apps/web/components/common/status-badge.tsx
+++ b/apps/web/components/common/status-badge.tsx
@@ -19,6 +19,10 @@ const statusConfig: Record<BudgetStatus, { label: string; className: string }> =
     label: '초과',
     className: 'bg-over/10 text-over border-over/20',
   },
+  UNSET: {
+    label: '미설정',
+    className: 'bg-muted text-muted-foreground border-border',
+  },
 };
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -50,6 +50,9 @@ const navItems: NavItem[] = [
     label: '설정',
     href: '/settings',
     icon: Settings,
+    children: [
+      { label: '카테고리 관리', href: '/settings/categories' },
+    ],
   },
 ];
 

--- a/apps/web/components/settings/category-editor-dialog.tsx
+++ b/apps/web/components/settings/category-editor-dialog.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import type { TransactionType, CategoryNode } from '@my-wallet/shared';
+
+export interface CategoryEditorSubmit {
+  name: string;
+  sortOrder: number;
+  parentId?: string | null;
+}
+
+interface CategoryEditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'create-root' | 'create-child' | 'edit';
+  initialName?: string;
+  initialSortOrder?: number;
+  initialParentId?: string | null;
+  type: TransactionType;
+  parentName?: string; // 소분류 생성 시 표시용
+  /** edit 모드에서 reparenting 대상 후보 목록 (type이 같은 활성 대분류만) */
+  parentOptions?: Array<Pick<CategoryNode, 'id' | 'name'>>;
+  /** edit 대상이 자식을 가진 대분류인지 — 참이면 parent 변경 차단 (2-depth 유지) */
+  hasChildren?: boolean;
+  /** edit 대상의 id — reparent 대상 목록에서 자기 자신 제외 */
+  editingId?: string;
+  onSubmit: (data: CategoryEditorSubmit) => Promise<void>;
+}
+
+const ROOT_SENTINEL = '__ROOT__';
+
+export function CategoryEditorDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialName = '',
+  initialSortOrder = 0,
+  initialParentId = null,
+  type,
+  parentName,
+  parentOptions = [],
+  hasChildren = false,
+  editingId,
+  onSubmit,
+}: CategoryEditorDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [sortOrder, setSortOrder] = useState(String(initialSortOrder));
+  const [parentId, setParentId] = useState<string>(initialParentId ?? ROOT_SENTINEL);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setSortOrder(String(initialSortOrder));
+      setParentId(initialParentId ?? ROOT_SENTINEL);
+      setError(null);
+    }
+  }, [open, initialName, initialSortOrder, initialParentId]);
+
+  const showReparent = mode === 'edit' && !hasChildren;
+  const availableParents = parentOptions.filter((p) => p.id !== editingId);
+
+  const title =
+    mode === 'create-root'
+      ? `대분류 추가 (${typeLabel(type)})`
+      : mode === 'create-child'
+        ? `소분류 추가${parentName ? ` - ${parentName}` : ''}`
+        : '카테고리 수정';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('카테고리 이름을 입력해주세요.');
+      return;
+    }
+    const sortOrderNum = parseInt(sortOrder, 10);
+    if (isNaN(sortOrderNum) || sortOrderNum < 0) {
+      setError('정렬 순서는 0 이상의 정수여야 합니다.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const payload: CategoryEditorSubmit = { name: trimmed, sortOrder: sortOrderNum };
+      if (showReparent) {
+        payload.parentId = parentId === ROOT_SENTINEL ? null : parentId;
+      }
+      await onSubmit(payload);
+      onOpenChange(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '저장에 실패했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">카테고리 이름</label>
+            <Input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 식비"
+              autoFocus
+            />
+          </div>
+
+          {showReparent && (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">상위 카테고리</label>
+              <Select value={parentId} onValueChange={setParentId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="상위 카테고리 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ROOT_SENTINEL}>
+                    <span className="font-medium">(대분류로 설정)</span>
+                  </SelectItem>
+                  {availableParents.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      <span>
+                        <span className="text-muted-foreground">└ </span>
+                        {p.name}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                변경 시 해당 대분류 아래로 이동합니다. 거래 이력은 유지됩니다.
+              </p>
+            </div>
+          )}
+
+          {mode === 'edit' && hasChildren && (
+            <p className="text-xs text-muted-foreground">
+              하위 카테고리가 있는 대분류는 소분류로 변경할 수 없습니다. 하위를 먼저 정리해주세요.
+            </p>
+          )}
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">정렬 순서</label>
+            <Input
+              type="number"
+              min={0}
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">숫자가 작을수록 먼저 표시됩니다.</p>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '저장 중...' : mode === 'edit' ? '수정' : '추가'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function typeLabel(type: TransactionType): string {
+  switch (type) {
+    case 'INCOME':
+      return '수입';
+    case 'EXPENSE':
+      return '지출';
+    case 'SAVING':
+      return '저축';
+  }
+}

--- a/apps/web/hooks/use-budget.ts
+++ b/apps/web/hooks/use-budget.ts
@@ -1,10 +1,16 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import type { BudgetAnalysisItem, MonthSummary } from '@my-wallet/shared';
+import type {
+  BudgetAnalysisItem,
+  MonthSummary,
+  CategoryNode,
+  TransactionType,
+} from '@my-wallet/shared';
 import {
   fetchTransactions,
   fetchCategories,
+  fetchCategoryTree,
   fetchMonthlySummary,
   fetchCategoryBreakdown,
   fetchBudgets,
@@ -151,15 +157,18 @@ interface UseCategoriesReturn {
   categories: Category[];
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 export function useCategories(): UseCategoriesReturn {
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
     fetchCategories()
       .then((res) => {
         if (!cancelled) setCategories(res);
@@ -171,9 +180,48 @@ export function useCategories(): UseCategoriesReturn {
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [tick]);
 
-  return { categories, loading, error };
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { categories, loading, error, refetch };
+}
+
+// ─── useCategoryTree ──────────────────────────────────────────────────────────
+
+interface UseCategoryTreeReturn {
+  tree: CategoryNode[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useCategoryTree(type?: TransactionType): UseCategoryTreeReturn {
+  const [tree, setTree] = useState<CategoryNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchCategoryTree(type)
+      .then((res) => {
+        if (!cancelled) setTree(res);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? '카테고리 트리를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [type, tick]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { tree, loading, error, refetch };
 }
 
 // ─── useMonthlySummary ────────────────────────────────────────────────────────

--- a/apps/web/lib/api/budget.ts
+++ b/apps/web/lib/api/budget.ts
@@ -4,6 +4,7 @@ import type {
   BudgetAnalysisItem,
   MonthSummary,
   PaginatedResponse,
+  CategoryNode,
 } from '@my-wallet/shared';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -12,6 +13,8 @@ export interface Category {
   id: string;
   name: string;
   type: TransactionType;
+  parentId: string | null;
+  sortOrder: number;
   isActive: boolean;
 }
 
@@ -131,13 +134,20 @@ export function fetchSavingCategories(): Promise<Category[]> {
 export interface CreateCategoryDto {
   name: string;
   type: 'INCOME' | 'EXPENSE' | 'SAVING';
+  parentId?: string | null;
   sortOrder?: number;
 }
 
 export interface UpdateCategoryDto {
   name?: string;
+  parentId?: string | null;
   sortOrder?: number;
   isActive?: boolean;
+}
+
+export function fetchCategoryTree(type?: TransactionType): Promise<CategoryNode[]> {
+  const query = type ? `?type=${type}` : '';
+  return apiClient.get<CategoryNode[]>(`/categories/tree${query}`);
 }
 
 export function createCategory(dto: CreateCategoryDto): Promise<Category> {

--- a/packages/database/prisma/migrations/20260420000000_category_parent_id/migration.sql
+++ b/packages/database/prisma/migrations/20260420000000_category_parent_id/migration.sql
@@ -1,0 +1,26 @@
+-- 2-depth 카테고리 지원: parentId(self-ref) 추가
+-- 기존 카테고리는 모두 parentId=NULL인 leaf로 유지되어 데이터 손실 없음
+-- 스타일: init 마이그레이션 (20260323001543_init)과 일관되게 비한정자 사용
+-- (Prisma multiSchema가 search_path를 my_wallet으로 설정)
+
+-- AlterTable: parent_id 컬럼 추가
+ALTER TABLE "categories" ADD COLUMN "parent_id" TEXT;
+
+-- DropIndex: 기존 unique(name, type) 제거
+DROP INDEX IF EXISTS "categories_name_type_key";
+
+-- CreateIndex: 확장된 unique(name, type, parent_id)
+-- 주의: parent_id가 NULL이면 PostgreSQL 표준상 "distinct"로 간주되어
+-- 같은 (name, type, NULL) 로우가 복수 존재 가능. 애플리케이션 레이어에서
+-- 중복 루트 카테고리 생성을 차단한다 (CategoryController).
+CREATE UNIQUE INDEX "categories_name_type_parent_id_key"
+  ON "categories"("name", "type", "parent_id");
+
+-- CreateIndex: parent_id 단독 조회용
+CREATE INDEX "categories_parent_id_idx" ON "categories"("parent_id");
+
+-- AddForeignKey: self-referential FK (RESTRICT: 자식 있는 부모 삭제 차단)
+ALTER TABLE "categories"
+  ADD CONSTRAINT "categories_parent_id_fkey"
+  FOREIGN KEY ("parent_id") REFERENCES "categories"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -47,13 +47,17 @@ model Category {
   id        String          @id @default(cuid())
   name      String
   type      TransactionType
+  parentId  String?         @map("parent_id")
   sortOrder Int             @default(0) @map("sort_order")
   isActive  Boolean         @default(true) @map("is_active")
 
+  parent       Category?     @relation("CategoryTree", fields: [parentId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  children     Category[]    @relation("CategoryTree")
   transactions Transaction[]
   budgets      Budget[]
 
-  @@unique([name, type])
+  @@unique([name, type, parentId])
+  @@index([parentId])
   @@map("categories")
   @@schema("my_wallet")
 }

--- a/packages/shared/src/types/budget.ts
+++ b/packages/shared/src/types/budget.ts
@@ -1,16 +1,20 @@
 export type TransactionType = 'INCOME' | 'EXPENSE' | 'SAVING';
 
-export type BudgetStatus = 'GOOD' | 'WARNING' | 'OVER';
+export type BudgetStatus = 'GOOD' | 'WARNING' | 'OVER' | 'UNSET';
 
 export interface BudgetAnalysisItem {
   categoryId: string;
   categoryName: string;
   type: TransactionType;
+  parentId: string | null;
+  isParent: boolean;
+  isBudgeted: boolean;
   budget: number;
   actual: number;
   difference: number;
   achievementRate: number;
   status: BudgetStatus;
+  recommendation: number;
 }
 
 export interface MonthSummary {
@@ -19,4 +23,14 @@ export interface MonthSummary {
   totalExpense: number;
   totalSaving: number;
   balance: number;
+}
+
+export interface CategoryNode {
+  id: string;
+  name: string;
+  type: TransactionType;
+  parentId: string | null;
+  sortOrder: number;
+  isActive: boolean;
+  children: CategoryNode[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
       '@nestjs/cli':
         specifier: ^11.0.0
         version: 11.0.16(@types/node@22.19.15)
@@ -90,6 +93,9 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.0
         version: 4.0.1
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.15)
@@ -99,6 +105,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
   apps/web:
     dependencies:
@@ -567,6 +576,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -581,6 +628,26 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1692,6 +1759,65 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@typescript-eslint/eslint-plugin@8.58.2':
+    resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.58.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.58.2':
+    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.58.2':
+    resolution: {integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1752,6 +1878,11 @@ packages:
     engines: {node: '>=10.13.0'}
     peerDependencies:
       acorn: ^8.14.0
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -2187,6 +2318,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   deepmerge-ts@7.1.5:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
@@ -2307,14 +2441,52 @@ packages:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -2327,6 +2499,10 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -2372,6 +2548,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
@@ -2380,6 +2559,19 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   file-type@21.3.2:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
@@ -2396,6 +2588,17 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fork-ts-checker-webpack-plugin@9.1.0:
     resolution: {integrity: sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==}
@@ -2470,6 +2673,10 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -2480,6 +2687,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2523,6 +2734,14 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2558,6 +2777,10 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2565,6 +2788,10 @@ packages:
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -2769,6 +2996,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -2777,6 +3007,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2799,6 +3032,9 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -2806,6 +3042,10 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   libphonenumber-js@1.12.40:
     resolution: {integrity: sha512-HKGs7GowShNls3Zh+7DTr6wYpPk5jC78l508yQQY3e8ZgJChM3A9JZghmMJZuK+5bogSfuTafpjksGSR3aMIEg==}
@@ -2899,6 +3139,10 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -2919,6 +3163,9 @@ packages:
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
@@ -3120,6 +3367,10 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -3135,6 +3386,10 @@ packages:
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3209,6 +3464,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -3241,6 +3500,10 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -3640,6 +3903,10 @@ packages:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -3654,6 +3921,12 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   ts-jest@29.4.6:
     resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
@@ -3702,6 +3975,10 @@ packages:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -3724,6 +4001,13 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript-eslint@8.58.2:
+    resolution: {integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3837,6 +4121,10 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
@@ -4218,6 +4506,52 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -4234,6 +4568,22 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -5334,6 +5684,97 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
+      eslint: 9.39.4(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.58.2':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
+
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.58.2': {}
+
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.58.2':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      eslint-visitor-keys: 5.0.1
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -5420,6 +5861,10 @@ snapshots:
       negotiator: 1.0.0
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
@@ -5855,6 +6300,8 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-is@0.1.4: {}
+
   deepmerge-ts@7.1.5: {}
 
   deepmerge@4.3.1: {}
@@ -5971,12 +6418,76 @@ snapshots:
 
   escape-string-regexp@2.0.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -5985,6 +6496,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -6059,6 +6572,8 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-levenshtein@2.0.6: {}
+
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
@@ -6066,6 +6581,14 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   file-type@21.3.2:
     dependencies:
@@ -6095,6 +6618,18 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
@@ -6176,6 +6711,10 @@ snapshots:
       nypm: 0.6.5
       pathe: 2.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-to-regexp@0.4.1: {}
 
   glob@13.0.0:
@@ -6192,6 +6731,8 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globals@14.0.0: {}
 
   gopd@1.2.0: {}
 
@@ -6232,6 +6773,10 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6261,9 +6806,15 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-generator-fn@2.1.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-interactive@1.0.0: {}
 
@@ -6649,11 +7200,15 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
@@ -6689,9 +7244,18 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kleur@3.0.3: {}
 
   leven@3.1.0: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   libphonenumber-js@1.12.40: {}
 
@@ -6754,6 +7318,10 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -6767,6 +7335,8 @@ snapshots:
   lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
 
@@ -6939,6 +7509,15 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -6962,6 +7541,10 @@ snapshots:
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-try@2.2.0: {}
 
@@ -7020,6 +7603,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.4: {}
+
   pirates@4.0.7: {}
 
   pkg-dir@4.2.0:
@@ -7053,6 +7638,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
 
   pretty-format@29.7.0:
     dependencies:
@@ -7475,6 +8062,11 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -7488,6 +8080,10 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
@@ -7540,6 +8136,10 @@ snapshots:
       '@turbo/windows-64': 2.8.20
       '@turbo/windows-arm64': 2.8.20
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
@@ -7558,6 +8158,17 @@ snapshots:
       mime-types: 3.0.2
 
   typedarray@0.0.6: {}
+
+  typescript-eslint@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -7684,6 +8295,8 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
 


### PR DESCRIPTION
## Summary

**Backend (2-depth category + rollup analysis):**
- Prisma schema: Category.parentId self-ref with composite unique (name, type, parentId)
- Category controller: new `GET /categories/tree?type` endpoint, parent/leaf CRUD with 2-depth guards (type consistency, cycle prevention, active-parent enforcement, 409 on delete-with-children)
- BudgetAnalysisService rewrite: returns ALL active categories (not just budgeted), parent-rollup actual computation, UNSET status for unbudgeted, 3-month recommendation engine
- Migration service: `findFirst(parentId:null)` fallback priority for legacy CSV imports (prevents ambiguous matching post-hierarchy)

**Frontend (UX overhaul):**
- `/budget/analysis` rewrite: tabs (지출/저축/수입), tree with expand/collapse, 4-column sort, completion meter (N/M categories set), inline `+설정` button with recommended amount, parent-row rollup-cap tooltip
- `/settings/categories` NEW: tree editor — create/edit/delete, edit-mode reparenting UI
- `/settings` simplified hub
- BudgetForm/TransactionForm: hierarchical category select (parent bolded, children with └ indent)
- New components: BudgetAnalysisTree (flatMap render with sort), BudgetCompletionMeter, CategoryEditorDialog

**Infrastructure:**
- API ESLint v9 flat config bootstrapped (was broken: `eslint` binary missing)
- `TODOS.md` created with 6 follow-ups identified during review

**Not shipped (deferred to TODOS):**
- Leaf-only enforcement on transactions/budgets (relaxed semantic retained — design doc premise #3 updated)
- Dynamic recommendations divisor (currently fixed 3)
- Web test infra (Vitest + RTL)
- Tree-ordering DRY refactor (3 duplicate impls identified)

## Test Coverage

```
CODE PATH COVERAGE
===========================
[+] budget-analysis.service.ts   17/17 paths tested ★★★ (rollup + UNSET + boundary values)
[+] category.controller.ts       23/23 paths tested ★★★ (findTree/create/update/remove + regression)
[+] migration.service.ts         existing 19 tests green (fallback covered implicitly)
[+] Web components               manual QA only (no test infra — in TODOS)

─────────────────────────────────
API COVERAGE: 40/41 paths (98%) ★★★
Tests: 226 → 249 (+23 new)
─────────────────────────────────
```

**Coverage gate: PASS (98% ≥ 80% target).**

## Pre-Landing Review

Ran 3 specialist subagents in parallel (Testing, Maintainability, Data Migration) + 3 prior /plan-eng-review passes this session.

- **Critical findings:** 5 from Data Migration specialist
  - Schema prefix inconsistency (AUTO-FIXED: migration SQL now matches init style unqualified)
  - Drop index schema mismatch (fixed by above)
  - Rename migration `"Category"` drift (pre-existing, added to TODOS P1)
  - Leaf-only enforcement missing in transaction.service/budget.service (USER DECISION: keep relaxed semantic, design doc premise updated)
- **Informational:** 21 findings (testing gaps + maintainability DRY + NULLS NOT DISTINCT) — all deferred to TODOS or NOT in scope

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

```
15/15 DONE (10 from original design doc + 5 from eng review 2nd/3rd pass follow-ups)
```

Design doc: `~/.gstack/projects/my-wallet/bangs-main-design-20260420-072718.md`
Design Review: ran via Fix-First in pre-landing review (design-checklist style).

## Verification Results

Local dev server not running — skipped /qa-only auto-verification. Manual QA recommended post-merge against Render prod after `pnpm db:migrate`.

## TODOS

Created `TODOS.md` with 6 follow-up items:
- **P1:** Rename migration drift verification (prod DB)
- **P2:** Recommendations divisor dynamic, web test infra
- **P3:** DRY tree-ordering util, NULLS NOT DISTINCT, dialog prop cleanup + tooltip copy constant

## Test plan

- [x] API jest: 249/249 passing
- [x] API build: successful (`nest build`)
- [x] API lint: 0 errors, 7 pre-existing warnings (now auditable, previously broken)
- [x] Web compile + typecheck: successful (`next build` — standalone symlink EPERM is Windows-only, irrelevant for Render deploy)
- [ ] Post-merge: run `pnpm db:migrate` on Render Postgres
- [ ] Post-merge: manual QA against https://my-wallet-web.onrender.com/
  - Create parent category → create child → assign budget → view /budget/analysis tree
  - Verify existing flat categories still work (no data loss)
  - Verify `+설정` inline add flow with recommendation
  - Verify parent-row tooltip
  - Verify reparent flow in /settings/categories edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)